### PR TITLE
Supervisor setup with 2 dumb processes

### DIFF
--- a/data_platform/__init__.py
+++ b/data_platform/__init__.py
@@ -1,0 +1,18 @@
+
+import os
+import logging
+from dotenv import load_dotenv
+
+
+# get enviroment variables from .env file, if not already set
+load_dotenv()
+
+# configure logging
+logLevel = logging.ERROR
+if os.environ.get('ENV', '') == 'local':
+  logLevel = logging.INFO
+# config
+logging.basicConfig(
+  format='%(asctime)s %(levelname)s %(message)s',
+  level=logLevel
+)

--- a/data_platform/batch/cubic_ods/process_incoming.py
+++ b/data_platform/batch/cubic_ods/process_incoming.py
@@ -1,0 +1,13 @@
+
+import logging
+import time
+
+
+def run():
+  # sample process
+  logging.error('START process_incoming')
+  time.sleep(10)
+  logging.error('END process_incoming (Took 10 seconds)')
+
+if __name__ == '__main__':
+  run()

--- a/data_platform/batch/cubic_ods/start_ingestion.py
+++ b/data_platform/batch/cubic_ods/start_ingestion.py
@@ -1,0 +1,13 @@
+
+import logging
+import time
+
+
+def run():
+  # sample process
+  logging.error('START start_ingestion')
+  time.sleep(10)
+  logging.error('END start_ingestion (Took 10 seconds)')
+
+if __name__ == '__main__':
+  run()

--- a/supervisor/conf/dataplatform.conf
+++ b/supervisor/conf/dataplatform.conf
@@ -1,0 +1,42 @@
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisord]
+logfile=/tmp/supervisord.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=info
+pidfile=/tmp/supervisord.pid
+nodaemon=false
+silent=false
+minfds=1024
+minprocs=200
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+; -------------------------------------------------------------------------------------------------
+
+[program:cubic_ods__process_incoming]
+command=/usr/local/bin/python -m supervisor.cubic_ods__process_incoming
+directory=/data_platform
+autostart=true
+autorestart=true
+stopwaitsecs=300 ; wait 5 minutes before killing outright
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[program:cubic_ods__start_ingestion]
+command=/usr/local/bin/python -m supervisor.cubic_ods__start_ingestion
+directory=/data_platform
+autostart=true
+autorestart=true
+stopwaitsecs=300 ; wait 5 minutes before killing outright
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/supervisor/cubic_ods__process_incoming.py
+++ b/supervisor/cubic_ods__process_incoming.py
@@ -1,0 +1,26 @@
+
+import signal
+
+from data_platform.batch.cubic_ods import process_incoming
+
+
+def run():
+  # kill switch state
+  kill = {
+    'cubic_ods__process_incoming': False
+  }
+  # kill switch handler
+  def sigtermHandler(signum, frame):
+    kill['cubic_ods__process_incoming'] = True
+
+  # register handlers for termination signals, so we don't kill in mid process
+  signal.signal(signal.SIGINT, sigtermHandler) # SINGINT 2 (ctrl-c)
+  signal.signal(signal.SIGTERM, sigtermHandler) # SIGTERM 15 (docker stop)
+
+  # if we haven't killed the process, contiue calling it
+  while not kill.get('cubic_ods__process_incoming', False):
+    process_incoming.run()
+
+
+if __name__ == '__main__':
+  run()

--- a/supervisor/cubic_ods__process_incoming.py
+++ b/supervisor/cubic_ods__process_incoming.py
@@ -10,12 +10,12 @@ def run():
     'cubic_ods__process_incoming': False
   }
   # kill switch handler
-  def sigtermHandler(signum, frame):
+  def sigHandler(signum, frame):
     kill['cubic_ods__process_incoming'] = True
 
   # register handlers for termination signals, so we don't kill in mid process
-  signal.signal(signal.SIGINT, sigtermHandler) # SINGINT 2 (ctrl-c)
-  signal.signal(signal.SIGTERM, sigtermHandler) # SIGTERM 15 (docker stop)
+  signal.signal(signal.SIGINT, sigHandler) # SINGINT 2 (ctrl-c)
+  signal.signal(signal.SIGTERM, sigHandler) # SIGTERM 15 (docker stop)
 
   # if we haven't killed the process, contiue calling it
   while not kill.get('cubic_ods__process_incoming', False):

--- a/supervisor/cubic_ods__start_ingestion.py
+++ b/supervisor/cubic_ods__start_ingestion.py
@@ -1,0 +1,26 @@
+
+import signal
+
+from data_platform.batch.cubic_ods import start_ingestion
+
+
+def run():
+  # kill switch state
+  kill = {
+    'cubic_ods__start_ingestion': False
+  }
+  # kill switch handler
+  def sigtermHandler(signum, frame):
+    kill['cubic_ods__start_ingestion'] = True
+
+  # register handlers for termination signals, so we don't kill in mid process
+  signal.signal(signal.SIGINT, sigtermHandler) # SINGINT 2 (ctrl-c)
+  signal.signal(signal.SIGTERM, sigtermHandler) # SIGTERM 15 (docker stop)
+
+  # if we haven't killed the process, contiue calling it
+  while not kill.get('cubic_ods__start_ingestion', False):
+    start_ingestion.run()
+
+
+if __name__ == '__main__':
+  run()

--- a/supervisor/cubic_ods__start_ingestion.py
+++ b/supervisor/cubic_ods__start_ingestion.py
@@ -10,12 +10,12 @@ def run():
     'cubic_ods__start_ingestion': False
   }
   # kill switch handler
-  def sigtermHandler(signum, frame):
+  def sigHandler(signum, frame):
     kill['cubic_ods__start_ingestion'] = True
 
   # register handlers for termination signals, so we don't kill in mid process
-  signal.signal(signal.SIGINT, sigtermHandler) # SINGINT 2 (ctrl-c)
-  signal.signal(signal.SIGTERM, sigtermHandler) # SIGTERM 15 (docker stop)
+  signal.signal(signal.SIGINT, sigHandler) # SINGINT 2 (ctrl-c)
+  signal.signal(signal.SIGTERM, sigHandler) # SIGTERM 15 (docker stop)
 
   # if we haven't killed the process, contiue calling it
   while not kill.get('cubic_ods__start_ingestion', False):


### PR DESCRIPTION
### In Action

See it in action with these steps:

1. Build container:
```sh
# for Podman, substitute 'docker' for 'podman'
docker build --no-cache -t data_platform_main__local -f docker/Dockerfile.main .
```

2. Run container:
```sh
# for Podman, substitute 'docker' for 'podman'
docker run --rm --volume $PWD:/data_platform:ro data_platform_main__local supervisord -n -c /data_platform/supervisor/conf/dataplatform.conf
```

3. Stop container with CTRL-C. (Note: Container will not stop right away.)

### Links

* [Asana](https://app.asana.com/0/1201701089427502/1201701089427505/f)