### PR TITLE
[code] fix: tests were not working with prefixes env variables set

### DIFF
--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/process_incoming.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/process_incoming.ex
@@ -75,6 +75,9 @@ defmodule ExCubicOdsIngestion.ProcessIncoming do
         lib_ex_aws: state.lib_ex_aws
       )
       |> Enum.filter(&Map.has_key?(&1, :key))
+      |> Enum.map(fn object ->
+        %{object | key: String.replace_prefix(object[:key], incoming_prefix, "")}
+      end)
       |> CubicOdsLoad.insert_new_from_objects_with_table(table)
     end
 

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/process_incoming.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/process_incoming.ex
@@ -54,13 +54,13 @@ defmodule ExCubicOdsIngestion.ProcessIncoming do
   # server helper functions
   @spec run(t) :: :ok
   def run(state) do
-    bucket = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_incoming)
-    prefix = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
+    incoming_bucket = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_incoming)
+    incoming_prefix = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
 
     table_prefixes =
-      bucket
+      incoming_bucket
       |> S3Scan.list_objects_v2(
-        prefix: "#{prefix}cubic_ods_qlik/",
+        prefix: "#{incoming_prefix}cubic_ods_qlik/",
         delimiter: "/",
         lib_ex_aws: state.lib_ex_aws
       )
@@ -69,8 +69,11 @@ defmodule ExCubicOdsIngestion.ProcessIncoming do
       |> CubicOdsTable.filter_to_existing_prefixes()
 
     for {table_prefix, table} <- table_prefixes do
-      bucket
-      |> S3Scan.list_objects_v2(prefix: table_prefix, lib_ex_aws: state.lib_ex_aws)
+      incoming_bucket
+      |> S3Scan.list_objects_v2(
+        prefix: "#{incoming_prefix}#{table_prefix}",
+        lib_ex_aws: state.lib_ex_aws
+      )
       |> Enum.filter(&Map.has_key?(&1, :key))
       |> CubicOdsLoad.insert_new_from_objects_with_table(table)
     end

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/process_incoming.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/process_incoming.ex
@@ -65,7 +65,7 @@ defmodule ExCubicOdsIngestion.ProcessIncoming do
         lib_ex_aws: state.lib_ex_aws
       )
       |> Stream.filter(&Map.has_key?(&1, :prefix))
-      |> Enum.map(&Map.fetch!(&1, :prefix))
+      |> Enum.map(fn %{prefix: prefix} -> String.replace_prefix(prefix, incoming_prefix, "") end)
       |> CubicOdsTable.filter_to_existing_prefixes()
 
     for {table_prefix, table} <- table_prefixes do

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/schema/cubic_ods_table.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/schema/cubic_ods_table.ex
@@ -54,10 +54,15 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsTable do
   """
   @spec filter_to_existing_prefixes(Enumerable.t()) :: [{String.t(), t()}]
   def filter_to_existing_prefixes(prefixes) do
-    # strip any change tracking suffix
+    incoming_prefix = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
+
+    # strip incoming bucket prefix as it will not be in the database
+    without_incoming_prefix = Enum.map(prefixes, &String.replace_prefix(&1, incoming_prefix, ""))
+
+    # strip any change tracking suffix, and eliminate dups from list
     without_change_tracking =
-      prefixes
-      |> MapSet.new(&String.replace_suffix(&1, "__ct/", "/"))
+      without_incoming_prefix
+      |> MapSet.new(&replace_change_tracking_suffix(&1))
       |> Enum.to_list()
 
     query =
@@ -70,8 +75,8 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsTable do
       |> Repo.all()
       |> Map.new(&{&1.s3_prefix, &1})
 
-    for prefix <- prefixes,
-        short_prefix = String.replace_suffix(prefix, "__ct/", "/"),
+    for prefix <- without_incoming_prefix,
+        short_prefix = replace_change_tracking_suffix(prefix),
         %__MODULE__{} = table <- [Map.get(valid_prefix_map, short_prefix)] do
       {prefix, table}
     end
@@ -85,5 +90,10 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsTable do
       end)
 
     table_rec
+  end
+
+  @spec replace_change_tracking_suffix(String.t()) :: String.t()
+  defp replace_change_tracking_suffix(prefix) do
+    String.replace_suffix(prefix, "__ct/", "/")
   end
 end

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_load_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_load_test.exs
@@ -8,13 +8,12 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
 
   setup do
     table = Repo.insert!(MockExAws.Data.table())
-    {:ok, %{table: table}}
+    {:ok, %{table: table, load_objects: MockExAws.Data.load_objects_without_bucket_prefix()}}
   end
 
   describe "insert_new_from_objects_with_table/1" do
-    test "providing a non-empty list of objects", %{table: table} do
-      {:ok, new_load_recs} =
-        CubicOdsLoad.insert_new_from_objects_with_table(MockExAws.Data.load_objects(), table)
+    test "providing a non-empty list of objects", %{table: table, load_objects: load_objects} do
+      {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
 
       assert [
                %{
@@ -46,17 +45,21 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
   end
 
   describe "get_by_objects/1" do
-    test "getting records just added by providing the list we added from", %{table: table} do
-      load_objects = MockExAws.Data.load_objects()
+    test "getting records just added by providing the list we added from", %{
+      table: table,
+      load_objects: load_objects
+    } do
       {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
 
       assert new_load_recs ==
                CubicOdsLoad.get_by_objects(load_objects)
     end
 
-    test "getting no records by providing a list with a load object not in db", %{table: table} do
-      {:ok, _new_load_recs} =
-        CubicOdsLoad.insert_new_from_objects_with_table(MockExAws.Data.load_objects(), table)
+    test "getting no records by providing a list with a load object not in db", %{
+      table: table,
+      load_objects: load_objects
+    } do
+      {:ok, _new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
 
       assert [] ==
                CubicOdsLoad.get_by_objects([
@@ -79,8 +82,8 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
   end
 
   describe "not_added/2" do
-    test "object NOT found in database records" do
-      load_object = List.first(MockExAws.Data.load_objects())
+    test "object NOT found in database records", %{load_objects: load_objects} do
+      load_object = List.first(load_objects)
 
       load_recs = [
         %CubicOdsLoad{
@@ -92,8 +95,8 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
       assert CubicOdsLoad.not_added(load_object, load_recs)
     end
 
-    test "object found in database records" do
-      load_object = List.first(MockExAws.Data.load_objects())
+    test "object found in database records", %{load_objects: load_objects} do
+      load_object = List.first(load_objects)
 
       load_recs = [
         %CubicOdsLoad{
@@ -107,10 +110,12 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
   end
 
   describe "get_status_ready/0" do
-    test "getting load records with the status 'ready'", %{table: table} do
+    test "getting load records with the status 'ready'", %{
+      table: table,
+      load_objects: load_objects
+    } do
       # insert records as ready
-      {:ok, new_load_recs} =
-        CubicOdsLoad.insert_new_from_objects_with_table(MockExAws.Data.load_objects(), table)
+      {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
 
       # set the first record to 'archived'
       {:ok, _archived_load_rec} =
@@ -128,10 +133,9 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
   end
 
   describe "update/2" do
-    test "setting an 'archived' status", %{table: table} do
+    test "setting an 'archived' status", %{table: table, load_objects: load_objects} do
       # insert records as ready
-      {:ok, new_load_recs} =
-        CubicOdsLoad.insert_new_from_objects_with_table(MockExAws.Data.load_objects(), table)
+      {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
 
       # use the first record
       first_load_rec = List.first(new_load_recs)
@@ -148,10 +152,12 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
       assert [] == CubicOdsLoad.get_many_with_table([])
     end
 
-    test "getting records by passing load records with tables attached", %{table: table} do
+    test "getting records by passing load records with tables attached", %{
+      table: table,
+      load_objects: load_objects
+    } do
       # insert records as ready
-      {:ok, new_load_recs} =
-        CubicOdsLoad.insert_new_from_objects_with_table(MockExAws.Data.load_objects(), table)
+      {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
 
       # use the first record
       first_load_rec = List.first(new_load_recs)

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_table_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_table_test.exs
@@ -17,11 +17,14 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsTableTest do
 
   describe "filter_to_existing_prefixes/1" do
     test "limits the provided prefixes to those with an existing table", %{table: table} do
+      incoming_prefix =
+        Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
+
       prefixes = [
-        "cubic_ods_qlik/SAMPLE/",
-        "cubic_ods_qlik/SAMPLE__ct/",
-        "cubic_ods_qlik/SAMPLE_TABLE_WRONG/",
-        "other"
+        "#{incoming_prefix}cubic_ods_qlik/SAMPLE/",
+        "#{incoming_prefix}cubic_ods_qlik/SAMPLE__ct/",
+        "#{incoming_prefix}cubic_ods_qlik/SAMPLE_TABLE_WRONG/",
+        "#{incoming_prefix}other"
       ]
 
       expected = [

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_table_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_table_test.exs
@@ -17,14 +17,12 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsTableTest do
 
   describe "filter_to_existing_prefixes/1" do
     test "limits the provided prefixes to those with an existing table", %{table: table} do
-      incoming_prefix =
-        Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
-
+      # note: purposely leaving out incoming bucket prefix config
       prefixes = [
-        "#{incoming_prefix}cubic_ods_qlik/SAMPLE/",
-        "#{incoming_prefix}cubic_ods_qlik/SAMPLE__ct/",
-        "#{incoming_prefix}cubic_ods_qlik/SAMPLE_TABLE_WRONG/",
-        "#{incoming_prefix}other"
+        "cubic_ods_qlik/SAMPLE/",
+        "cubic_ods_qlik/SAMPLE__ct/",
+        "cubic_ods_qlik/SAMPLE_TABLE_WRONG/",
+        "other"
       ]
 
       expected = [

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/start_ingestion_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/start_ingestion_test.exs
@@ -17,7 +17,10 @@ defmodule ExCubicOdsIngestion.StartIngestionTest do
 
     # insert load records
     {:ok, load_recs} =
-      CubicOdsLoad.insert_new_from_objects_with_table(MockExAws.Data.load_objects(), table)
+      CubicOdsLoad.insert_new_from_objects_with_table(
+        MockExAws.Data.load_objects_without_bucket_prefix(),
+        table
+      )
 
     [first_load_rec, last_load_rec] = load_recs
 

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/workers/error_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/workers/error_test.exs
@@ -15,7 +15,7 @@ defmodule ExCubicOdsIngestion.Workers.ErrorTest do
       # insert load records
       {:ok, new_load_recs} =
         CubicOdsLoad.insert_new_from_objects_with_table(
-          MockExAws.Data.load_objects(),
+          MockExAws.Data.load_objects_without_bucket_prefix(),
           new_table_rec
         )
 

--- a/ex_cubic_ods_ingestion/test/support/ex_aws.ex
+++ b/ex_cubic_ods_ingestion/test/support/ex_aws.ex
@@ -7,11 +7,9 @@ defmodule MockExAws do
   def request(op, config_overrides \\ [])
 
   def request(%{service: :s3, http_method: :delete} = op, _config_overrides) do
-    incoming_prefix = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
-
     valid_paths =
       Enum.map(MockExAws.Data.load_objects(), fn load_object ->
-        "#{incoming_prefix}#{load_object[:key]}"
+        "#{load_object[:key]}"
       end)
 
     # deleting object

--- a/ex_cubic_ods_ingestion/test/support/ex_aws_data.ex
+++ b/ex_cubic_ods_ingestion/test/support/ex_aws_data.ex
@@ -44,4 +44,16 @@ defmodule MockExAws.Data do
       }
     ]
   end
+
+  @doc """
+  Helper function to eliminate duplication in tests that don't care about the bucket prefix.
+  """
+  @spec load_objects_without_bucket_prefix :: [map()]
+  def load_objects_without_bucket_prefix do
+    incoming_prefix = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
+
+    Enum.map(load_objects(), fn object ->
+      %{object | key: String.replace_prefix(object[:key], incoming_prefix, "")}
+    end)
+  end
 end

--- a/ex_cubic_ods_ingestion/test/support/ex_aws_data.ex
+++ b/ex_cubic_ods_ingestion/test/support/ex_aws_data.ex
@@ -23,10 +23,12 @@ defmodule MockExAws.Data do
   """
   @spec load_objects() :: [map()]
   def load_objects do
+    incoming_prefix = Application.fetch_env!(:ex_cubic_ods_ingestion, :s3_bucket_prefix_incoming)
+
     [
       %{
         e_tag: "\"abc123\"",
-        key: "cubic_ods_qlik/SAMPLE/LOAD1.csv",
+        key: "#{incoming_prefix}cubic_ods_qlik/SAMPLE/LOAD1.csv",
         last_modified: "2022-02-08T20:49:50.000Z",
         owner: nil,
         size: "197",
@@ -34,7 +36,7 @@ defmodule MockExAws.Data do
       },
       %{
         e_tag: "\"def123\"",
-        key: "cubic_ods_qlik/SAMPLE/LOAD2.csv",
+        key: "#{incoming_prefix}cubic_ods_qlik/SAMPLE/LOAD2.csv",
         last_modified: "2022-02-08T20:50:50.000Z",
         owner: nil,
         size: "123",


### PR DESCRIPTION
This PR addresses an issue in testing with bucket prefix environment variables being set, specifically the `S3_BUCKET_PREFIX_INCOMING`.

An [Asana ticket](https://app.asana.com/0/1201701089427502/1201998951371780/f) has also been created for an ADR to explain bucket prefixes and their purpose.
