### PR TITLE
[code] fix: snapshot now in iso 8601 + fix test

### DIFF
--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/archive.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/archive.ex
@@ -37,7 +37,7 @@ defmodule ExCubicOdsIngestion.Workers.Archive do
       Enum.join([
         archive_prefix,
         Path.dirname(load_rec.s3_key),
-        "/snapshot=#{Calendar.strftime(load_rec.snapshot, "%Y%m%d%H%M%S")}/",
+        "/snapshot=#{Calendar.strftime(load_rec.snapshot, "%Y%m%dT%H%M%SZ")}/",
         Path.basename(load_rec.s3_key)
       ])
 

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/error.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/error.ex
@@ -38,7 +38,7 @@ defmodule ExCubicOdsIngestion.Workers.Error do
       Enum.join([
         error_prefix,
         Path.dirname(load_rec.s3_key),
-        "/timestamp=#{Calendar.strftime(load_rec.s3_modified, "%Y%m%d%H%M%S")}/",
+        "/timestamp=#{Calendar.strftime(load_rec.s3_modified, "%Y%m%dT%H%M%SZ")}/",
         Path.basename(load_rec.s3_key)
       ])
 

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/ingest.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/ingest.ex
@@ -110,7 +110,7 @@ defmodule ExCubicOdsIngestion.Workers.Ingest do
       Enum.map(CubicOdsLoad.get_many_with_table(load_rec_ids), fn {load_rec, table_rec} ->
         %{
           s3_key: load_rec.s3_key,
-          snapshot: load_rec.snapshot,
+          snapshot: Calendar.strftime(load_rec.snapshot, "%Y%m%dT%H%M%SZ"),
           table_name: table_rec.name
         }
       end)

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/workers/ingest_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/workers/ingest_test.exs
@@ -3,6 +3,7 @@ defmodule ExCubicOdsIngestion.Workers.IngestTest do
   use Oban.Testing, repo: ExCubicOdsIngestion.Repo
 
   alias ExCubicOdsIngestion.Schema.CubicOdsLoad
+  alias ExCubicOdsIngestion.StartIngestion
   alias ExCubicOdsIngestion.Workers.Ingest
 
   require MockExAws
@@ -19,8 +20,12 @@ defmodule ExCubicOdsIngestion.Workers.IngestTest do
           new_table_rec
         )
 
+      # get records and update snapshots
       first_load_rec = List.first(new_load_recs)
+      StartIngestion.update_snapshot(first_load_rec)
+
       last_load_rec = List.last(new_load_recs)
+      StartIngestion.update_snapshot(last_load_rec)
 
       assert :ok =
                perform_job(Ingest, %{


### PR DESCRIPTION
This PR adjust the format of the snapshot string to be ISO 8601 compatible. It also fixes a test that didn't have the proper data setup.