### PR TITLE
[code] fix: wrong table is referenced for change tracking load

### DIFF
--- a/py_cubic_ods_ingestion/lib/py_cubic_ods_ingestion/ingest_incoming.py
+++ b/py_cubic_ods_ingestion/lib/py_cubic_ods_ingestion/ingest_incoming.py
@@ -42,16 +42,12 @@ def run() -> None:
             f"{os.path.dirname(load_s3_key)}/",
             env_dict.get("S3_BUCKET_PREFIX_INCOMING", ""),
         )
-        data_catalog_table_name = load["table_name"]
-
-        # for cdc, we want to suffix table name by '__ct'
-        if load_table_s3_prefix.endswith("__ct"):
-            data_catalog_table_name += "__ct"
+        data_catalog_table_name_suffix = job_helpers.get_table_name_suffix(load_table_s3_prefix)
 
         # create table dataframe using the data catalog table in glue
         table_df = glue_context.create_dynamic_frame.from_catalog(
             database=env_dict["GLUE_DATABASE_INCOMING"],
-            table_name=data_catalog_table_name,
+            table_name=f'{load["table_name"]}{data_catalog_table_name_suffix}',
             additional_options={"paths": [f's3://{env_dict["S3_BUCKET_INCOMING"]}/{load_s3_key}']},
             transformation_ctx=f"{job_name}_table_df_read",
         )

--- a/py_cubic_ods_ingestion/lib/py_cubic_ods_ingestion/job_helpers.py
+++ b/py_cubic_ods_ingestion/lib/py_cubic_ods_ingestion/job_helpers.py
@@ -62,3 +62,11 @@ def parse_args(env_arg: str, input_arg: str) -> typing.Tuple[dict, dict]:
         raise error
 
     return (env_dict, input_dict)
+
+
+def get_table_name_suffix(load_table_s3_prefix: str) -> str:
+    """
+    Table name suffix should be '__ct' if the S3 prefix is from change tracking.
+    """
+
+    return "__ct" if load_table_s3_prefix.endswith("__ct/") else ""

--- a/py_cubic_ods_ingestion/tests/test_job_helpers.py
+++ b/py_cubic_ods_ingestion/tests/test_job_helpers.py
@@ -38,3 +38,15 @@ def test_parse_args() -> None:
 
     # test invalid keys are ignored
     # assert ({}, {}) == job_helpers.parse_args("{\"key\":\"invalid\"}", "{\"key\":\"invalid\"}")
+
+
+def test_get_table_name_suffix() -> None:
+    """
+    Testing table name adjustment for change tracking prefixes.
+    """
+
+    # without ct
+    assert "" == job_helpers.get_table_name_suffix("cubic_ods_qlik/EDW.TEST/")
+
+    # with ct
+    assert "__ct" == job_helpers.get_table_name_suffix("cubic_ods_qlik/EDW.TEST__ct/")


### PR DESCRIPTION
This PR addresses an issue where the correct glue table was not being referenced for change tracking loads.