### PR TITLE
feat: add terraform area for local development resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ cover/
 
 # local development
 db_data/
+
+terraform/*
+!terraform/README.md

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,6 @@
-python 3.7.12
+adr-tools 3.0.0
 elixir 1.13.2-otp-24
 erlang 24.2.1
-adr-tools 3.0.0
 poetry 1.1.13
+python 3.7.12
+terraform 1.1.8

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,42 @@
+
+# Data Platform (Terraform)
+
+In general, CTD's policy for documenting infrastucture is through Terraform and the [devops](https://github.com/mbta/devops) repo.
+
+This area exists for management of infrastructure as it relates to **local development** of the Data Platform. As you develop resources, you might want to test out different setups. Files in this folder are purposely ignored, so as not interfere with other developers' resources.
+
+### Setup
+
+In root directory:
+```
+asdf add-plugin terraform
+asdf install
+```
+
+In this folder:
+```
+terraform init
+```
+
+### Examples
+
+Here are some of examples of things you might want to deploy for yourself.
+
+* Glue Databases
+```
+# glue.tf
+resource "aws_glue_catalog_database" "ggjura_incoming" {
+  name = "ggjura_incoming"
+}
+```
+
+* Glue Data Catalog Tables
+```
+# glue.tf
+```
+
+* Glue Jobs
+```
+# glue.tf
+
+```


### PR DESCRIPTION
This PR add a space for terraform files that may be used during local development. The README.md fill will evolve to include more examples as more stability comes to the platform.