### PR TITLE
[code] fix: handle retries on ingest worker error

### DIFF
--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/application.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/application.ex
@@ -39,6 +39,15 @@ defmodule ExCubicOdsIngestion.Application do
         []
       )
 
+    # attach a specific error handler for the 'ingest' Oban worker
+    :ok =
+      :telemetry.attach(
+        "oban-ingest-worker-error",
+        [:oban, :job, :exception],
+        &ExCubicOdsIngestion.ObanIngestWorkerError.handle_event/4,
+        []
+      )
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: ExCubicOdsIngestion.Supervisor]

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/oban_ingest_worker_error.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/oban_ingest_worker_error.ex
@@ -1,0 +1,36 @@
+defmodule ExCubicOdsIngestion.ObanIngestWorkerError do
+  @moduledoc """
+  Provides a way for Oban to update status of load upon a complete failure of an 'ingest' job.
+  """
+
+  alias ExCubicOdsIngestion.Schema.CubicOdsLoad
+
+  @spec handle_event(
+          :telemetry.event_name(),
+          :telemetry.event_measurements(),
+          :telemetry.event_metadata(),
+          :telemetry.handler_config()
+        ) :: [CubicOdsLoad.t()]
+  @doc """
+  Matches on the Ingest worker and when attempts equal max attempts, and updates the status
+  of load once all attempts have failed.
+  """
+  def handle_event(
+        [:oban, :job, :exception],
+        _measure,
+        %{
+          worker: "ExCubicOdsIngestion.Workers.Ingest",
+          attempt: attempts,
+          max_attempts: attempts
+        } = meta,
+        _config
+      ) do
+    %{"load_rec_ids" => load_rec_ids} = meta.args
+
+    CubicOdsLoad.update_many(load_rec_ids, status: "ready_for_erroring")
+  end
+
+  def handle_event([:oban, :job, :exception], _measure, _meta, _config) do
+    []
+  end
+end

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/schema/cubic_ods_load.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/schema/cubic_ods_load.ex
@@ -184,9 +184,9 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoad do
   end
 
   # @todo consider making this more specific to use cases
-  @spec update_many([integer()], Keyword.t()) :: [integer()]
+  @spec update_many([integer()], Keyword.t()) :: [t()]
   def update_many(load_rec_ids, change) do
-    {:ok, updated_load_rec_ids} =
+    {:ok, {_count, updated_load_recs}} =
       Repo.transaction(fn ->
         Repo.update_all(
           query_many(load_rec_ids),
@@ -194,7 +194,7 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoad do
         )
       end)
 
-    updated_load_rec_ids
+    updated_load_recs
   end
 
   # private

--- a/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/ingest.ex
+++ b/ex_cubic_ods_ingestion/lib/ex_cubic_ods_ingestion/workers/ingest.ex
@@ -46,13 +46,12 @@ defmodule ExCubicOdsIngestion.Workers.Ingest do
 
         CubicOdsLoad.update_many(load_rec_ids, status: "ready_for_archiving")
 
+        :ok
+
       _other_glue_job_run_state ->
-        Logger.error("#{@log_prefix} Glue Job Run Status: #{Jason.encode!(glue_job_run_status)}")
-
-        CubicOdsLoad.update_many(load_rec_ids, status: "ready_for_erroring")
+        # note: error will be handled within ObanIngestWorkerError module
+        {:error, "Glue Job Run Status: #{Jason.encode!(glue_job_run_status)}"}
     end
-
-    :ok
   end
 
   @spec start_glue_job_run(module(), String.t(), String.t()) :: map()

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/oban_ingest_worker_error_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/oban_ingest_worker_error_test.exs
@@ -1,0 +1,57 @@
+defmodule ExCubicOdsIngestion.Schema.ObanIngestWorkerErrorTest do
+  @moduledoc """
+  Test for ingest worker error handler.
+  """
+
+  use ExCubicOdsIngestion.DataCase, async: true
+
+  alias ExCubicOdsIngestion.ObanIngestWorkerError
+  alias ExCubicOdsIngestion.Schema.CubicOdsLoad
+
+  setup do
+    table = Repo.insert!(MockExAws.Data.table())
+    {:ok, %{table: table, load_objects: MockExAws.Data.load_objects_without_bucket_prefix()}}
+  end
+
+  describe "handle_event/4" do
+    test "taking action on attemps as it reaches max attempts", %{
+      table: table,
+      load_objects: load_objects
+    } do
+      {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
+
+      new_load_rec_ids = Enum.map(new_load_recs, fn rec -> rec.id end)
+
+      worker_meta_data = %{
+        worker: "ExCubicOdsIngestion.Workers.Ingest",
+        attempt: 1,
+        max_attempts: 2,
+        args: %{
+          "load_rec_ids" => new_load_rec_ids
+        }
+      }
+
+      # no updates should have been made
+      assert [] ==
+               ObanIngestWorkerError.handle_event(
+                 [:oban, :job, :exception],
+                 nil,
+                 worker_meta_data,
+                 nil
+               )
+
+      # increment attempts
+      updated_load_recs =
+        ObanIngestWorkerError.handle_event(
+          [:oban, :job, :exception],
+          nil,
+          %{worker_meta_data | attempt: 2},
+          nil
+        )
+
+      # status should be updated for records
+      assert ["ready_for_erroring", "ready_for_erroring"] ==
+               Enum.map(updated_load_recs, fn rec -> rec.status end)
+    end
+  end
+end

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_load_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_load_test.exs
@@ -186,4 +186,17 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
                )
     end
   end
+
+  describe "update_many/2" do
+    test "updateing status to 'ready' for many IDs", %{table: table, load_objects: load_objects} do
+      {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
+
+      new_load_rec_ids = Enum.map(new_load_recs, fn rec -> rec.id end)
+
+      updated_load_recs = CubicOdsLoad.update_many(new_load_rec_ids, status: "ready")
+
+      assert ["ready", "ready"] ==
+               Enum.map(new_load_rec_ids, fn id -> CubicOdsLoad.get!(id).status end)
+    end
+  end
 end

--- a/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_load_test.exs
+++ b/ex_cubic_ods_ingestion/test/ex_cubic_ods_ingestion/schema/cubic_ods_load_test.exs
@@ -188,12 +188,12 @@ defmodule ExCubicOdsIngestion.Schema.CubicOdsLoadTest do
   end
 
   describe "update_many/2" do
-    test "updateing status to 'ready' for many IDs", %{table: table, load_objects: load_objects} do
+    test "updating status to 'ready' for many IDs", %{table: table, load_objects: load_objects} do
       {:ok, new_load_recs} = CubicOdsLoad.insert_new_from_objects_with_table(load_objects, table)
 
       new_load_rec_ids = Enum.map(new_load_recs, fn rec -> rec.id end)
 
-      updated_load_recs = CubicOdsLoad.update_many(new_load_rec_ids, status: "ready")
+      CubicOdsLoad.update_many(new_load_rec_ids, status: "ready")
 
       assert ["ready", "ready"] ==
                Enum.map(new_load_rec_ids, fn id -> CubicOdsLoad.get!(id).status end)


### PR DESCRIPTION
This PR addresses an issue where the Oban worker was not treating a Glue job error as an error in the Oban job.