### PR TITLE
[elixir] fix: glue throttling because of aggressiveness on oban's part.

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/ingest.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/ingest.ex
@@ -35,53 +35,22 @@ defmodule ExCubicIngestion.Workers.Ingest do
       end
 
     # start glue job
-    {env_payload, input_payload} = construct_glue_job_payload(load_rec_ids)
-    glue_job_start_request = start_glue_job_run(lib_ex_aws, env_payload, input_payload)
+    glue_job_start_request =
+      load_rec_ids
+      |> construct_glue_job_payload()
+      |> start_glue_job_run(lib_ex_aws)
 
     case glue_job_start_request do
       {:ok, %{"JobRunId" => glue_job_run_id}} ->
-        Logger.info("#{@log_prefix} Glue Job Run ID: #{glue_job_run_id}")
+        monitor_glue_job_run(glue_job_run_id, load_rec_ids, lib_ex_aws)
 
-        # monitor for success or failure state in glue job run
-        glue_job_run_status = get_glue_job_run_status(lib_ex_aws, glue_job_run_id)
-
-        case glue_job_run_status do
-          %{"JobRun" => %{"JobRunState" => "SUCCEEDED"}} ->
-            Logger.info(
-              "#{@log_prefix} Glue Job Run Status: #{Jason.encode!(glue_job_run_status)}"
-            )
-
-            CubicLoad.update_many(load_rec_ids, status: "ready_for_archiving")
-
-            :ok
-
-          _other_glue_job_run_state ->
-            # note: error will be handled within ObanIngestWorkerError module
-            {:error, "Glue Job Run Status: #{Jason.encode!(glue_job_run_status)}"}
-        end
-
-      {:error, {"ConcurrentRunsExceededException", message}} ->
-        Logger.warning(
-          "#{@log_prefix} Glue Job Start Request: ConcurrentRunsExceededException: #{message}"
-        )
-
-        {:snooze, 60}
-
-      {:error, {"ThrottlingException", message}} ->
-        Logger.warning("#{@log_prefix} Glue Job Start Request: ThrottlingException: #{message}")
-
-        {:snooze, 60}
-
-      # everything else is an error
       _glue_job_start_request_error ->
-        Logger.error("#{@log_prefix} Glue Job Start Request: #{glue_job_start_request}")
-
-        {:error, "Glue Job Start Request: #{glue_job_start_request}"}
+        handle_start_glue_job_error(glue_job_start_request)
     end
   end
 
-  @spec start_glue_job_run(module(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
-  defp start_glue_job_run(lib_ex_aws, env_payload, input_payload) do
+  @spec start_glue_job_run({String.t(), String.t()}, module()) :: {:ok, map()} | {:error, term()}
+  defp start_glue_job_run({env_payload, input_payload}, lib_ex_aws) do
     bucket_operations = Application.fetch_env!(:ex_cubic_ingestion, :s3_bucket_operations)
 
     prefix_operations = Application.fetch_env!(:ex_cubic_ingestion, :s3_bucket_prefix_operations)
@@ -201,5 +170,57 @@ defmodule ExCubicIngestion.Workers.Ingest do
     else
       load
     end
+  end
+
+  @doc """
+  Given a run ID, check status of it continously until it stops running. If its last
+  status is a success, update loads' status to archive, and let the worker know the job
+  was a success. Any other state should be considered an error for the job.
+  """
+  @spec monitor_glue_job_run(String.t(), [integer()], module()) :: Oban.Worker.result()
+  def monitor_glue_job_run(glue_job_run_id, load_rec_ids, lib_ex_aws) do
+    Logger.info("#{@log_prefix} Glue Job Run ID: #{glue_job_run_id}")
+
+    # monitor for success or failure state in glue job run
+    glue_job_run_status = get_glue_job_run_status(lib_ex_aws, glue_job_run_id)
+
+    case glue_job_run_status do
+      %{"JobRun" => %{"JobRunState" => "SUCCEEDED"}} ->
+        Logger.info("#{@log_prefix} Glue Job Run Status: #{Jason.encode!(glue_job_run_status)}")
+
+        CubicLoad.update_many(load_rec_ids, status: "ready_for_archiving")
+
+        :ok
+
+      _other_glue_job_run_state ->
+        # note: error will be handled within ObanIngestWorkerError module
+        {:error, "Glue Job Run Status: #{Jason.encode!(glue_job_run_status)}"}
+    end
+  end
+
+  @doc """
+  Not all failures are equal when starting a glue job. For when we have exceeded the max
+  concurrency, we just want to snooze the Oban job, so we can retry it again. Same thing
+  for any throttling errors. If any other error occurs, we will also error out the Oban job.
+  """
+  @spec handle_start_glue_job_error({:error, term()}) :: Oban.Worker.result()
+  def handle_start_glue_job_error({:error, {"ConcurrentRunsExceededException", message}}) do
+    Logger.info(
+      "#{@log_prefix} Glue Job Start Request: ConcurrentRunsExceededException: #{message}"
+    )
+
+    {:snooze, 60}
+  end
+
+  def handle_start_glue_job_error({:error, {"ThrottlingException", message}}) do
+    Logger.info("#{@log_prefix} Glue Job Start Request: ThrottlingException: #{message}")
+
+    {:snooze, 60}
+  end
+
+  def handle_start_glue_job_error({:error, {exception, message}}) do
+    Logger.error("#{@log_prefix} Glue Job Start Request: #{exception}: #{message}")
+
+    {:error, "Glue Job Start Request: #{exception}: #{exception}"}
   end
 end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/ingest_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/ingest_test.exs
@@ -2,131 +2,42 @@ defmodule ExCubicIngestion.Workers.IngestTest do
   use ExCubicIngestion.DataCase, async: true
   use Oban.Testing, repo: ExCubicIngestion.Repo
 
+  import ExCubicIngestion.TestFixtures, only: [setup_tables_loads: 1]
+
   alias ExCubicIngestion.Schema.CubicLoad
-  alias ExCubicIngestion.Schema.CubicOdsLoadSnapshot
-  alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
-  alias ExCubicIngestion.Schema.CubicTable
   alias ExCubicIngestion.Workers.Ingest
 
   require MockExAws
 
-  setup do
-    # insert tables
-    dmap_table =
-      Repo.insert!(%CubicTable{
-        name: "cubic_dmap__sample",
-        s3_prefix: "cubic/dmap/sample/"
-      })
-
-    ods_table =
-      Repo.insert!(%CubicTable{
-        name: "cubic_ods_qlik__sample",
-        s3_prefix: "cubic/ods_qlik/SAMPLE/"
-      })
-
-    # insert ODS table
-    ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv"
-    ods_snapshot = ~U[2022-01-01 20:49:50Z]
-
-    Repo.insert!(%CubicOdsTableSnapshot{
-      table_id: ods_table.id,
-      snapshot: ods_snapshot,
-      snapshot_s3_key: ods_snapshot_s3_key
-    })
-
-    # insert loads
-    dmap_load_1 =
-      Repo.insert!(%CubicLoad{
-        table_id: dmap_table.id,
-        status: "ready",
-        s3_key: "cubic/dmap/sample/20220101.csv",
-        s3_modified: ~U[2022-01-01 20:49:50Z],
-        s3_size: 197
-      })
-
-    dmap_load_2 =
-      Repo.insert!(%CubicLoad{
-        table_id: dmap_table.id,
-        status: "ready",
-        s3_key: "cubic/dmap/sample/20220102.csv",
-        s3_modified: ~U[2022-01-02 20:49:50Z],
-        s3_size: 197
-      })
-
-    ods_load_1 =
-      Repo.insert!(%CubicLoad{
-        table_id: ods_table.id,
-        status: "ready",
-        s3_key: ods_snapshot_s3_key,
-        s3_modified: ods_snapshot,
-        s3_size: 197
-      })
-
-    ods_load_2 =
-      Repo.insert!(%CubicLoad{
-        table_id: ods_table.id,
-        status: "ready",
-        s3_key: "cubic/ods_qlik/SAMPLE/LOAD2.csv",
-        s3_modified: ~U[2022-01-01 20:50:50Z],
-        s3_size: 197
-      })
-
-    # insert ODS loads
-    Repo.insert!(%CubicOdsLoadSnapshot{
-      load_id: ods_load_1.id,
-      snapshot: ods_snapshot
-    })
-
-    Repo.insert!(%CubicOdsLoadSnapshot{
-      load_id: ods_load_2.id,
-      snapshot: ods_snapshot
-    })
-
-    {:ok,
-     %{
-       dmap_table: dmap_table,
-       dmap_load_1: dmap_load_1,
-       dmap_load_2: dmap_load_2,
-       ods_snapshot: ods_snapshot,
-       ods_table: ods_table,
-       ods_load_1: ods_load_1,
-       ods_load_2: ods_load_2
-     }}
-  end
+  setup :setup_tables_loads
 
   describe "perform/1" do
-    test "run job", %{
-      dmap_load_1: dmap_load_1,
-      dmap_load_2: dmap_load_2,
-      ods_load_1: ods_load_1,
-      ods_load_2: ods_load_2
+    test "job successfully finished", %{
+      dmap_load: dmap_load,
+      ods_load: ods_load
     } do
       assert :ok =
                perform_job(Ingest, %{
-                 load_rec_ids: [dmap_load_1.id, dmap_load_2.id, ods_load_1.id, ods_load_2.id],
+                 load_rec_ids: [dmap_load.id, ods_load.id],
                  lib_ex_aws: "MockExAws"
                })
 
-      assert "ready_for_archiving" == CubicLoad.get!(dmap_load_1.id).status
+      assert ["ready_for_archiving", "ready_for_archiving"] == [
+               CubicLoad.get!(dmap_load.id).status,
+               CubicLoad.get!(ods_load.id).status
+             ]
     end
   end
 
   describe "construct_glue_job_payload/1" do
     test "payload is contructed correctly with ods and dmap data", %{
-      dmap_table: dmap_table,
-      dmap_load_1: dmap_load_1,
-      dmap_load_2: dmap_load_2,
-      ods_snapshot: ods_snapshot,
-      ods_table: ods_table,
-      ods_load_1: ods_load_1,
-      ods_load_2: ods_load_2
+      dmap_load: dmap_load,
+      ods_load: ods_load
     } do
       {_actual_env, actual_input} =
         Ingest.construct_glue_job_payload([
-          dmap_load_1.id,
-          dmap_load_2.id,
-          ods_load_1.id,
-          ods_load_2.id
+          dmap_load.id,
+          ods_load.id
         ])
 
       actual_input_decoded = Jason.decode!(actual_input)
@@ -134,43 +45,23 @@ defmodule ExCubicIngestion.Workers.IngestTest do
       expected_input = %{
         "loads" => [
           %{
-            "id" => dmap_load_1.id,
-            "s3_key" => dmap_load_1.s3_key,
-            "table_name" => dmap_table.name,
+            "id" => dmap_load.id,
+            "s3_key" => "cubic/dmap/sample/20220101.csv",
+            "table_name" => "cubic_dmap__sample",
             "partition_columns" => [
-              %{"name" => "identifier", "value" => Path.basename(dmap_load_1.s3_key)}
+              %{"name" => "identifier", "value" => "20220101.csv"}
             ]
           },
           %{
-            "id" => dmap_load_2.id,
-            "s3_key" => dmap_load_2.s3_key,
-            "table_name" => dmap_table.name,
-            "partition_columns" => [
-              %{"name" => "identifier", "value" => Path.basename(dmap_load_2.s3_key)}
-            ]
-          },
-          %{
-            "id" => ods_load_1.id,
-            "s3_key" => ods_load_1.s3_key,
-            "table_name" => ods_table.name,
+            "id" => ods_load.id,
+            "s3_key" => "cubic/ods_qlik/SAMPLE/LOAD1.csv",
+            "table_name" => "cubic_ods_qlik__sample",
             "partition_columns" => [
               %{
                 "name" => "snapshot",
-                "value" => Calendar.strftime(ods_snapshot, "%Y%m%dT%H%M%SZ")
+                "value" => "20220101T204950Z"
               },
-              %{"name" => "identifier", "value" => Path.basename(ods_load_1.s3_key)}
-            ]
-          },
-          %{
-            "id" => ods_load_2.id,
-            "s3_key" => ods_load_2.s3_key,
-            "table_name" => ods_table.name,
-            "partition_columns" => [
-              %{
-                "name" => "snapshot",
-                "value" => Calendar.strftime(ods_snapshot, "%Y%m%dT%H%M%SZ")
-              },
-              %{"name" => "identifier", "value" => Path.basename(ods_load_2.s3_key)}
+              %{"name" => "identifier", "value" => "LOAD1.csv"}
             ]
           }
         ]
@@ -178,6 +69,51 @@ defmodule ExCubicIngestion.Workers.IngestTest do
 
       assert expected_input["loads"] ==
                Enum.sort_by(actual_input_decoded["loads"], & &1["id"])
+    end
+  end
+
+  describe "monitor_glue_job_run/3" do
+    test "monitoring a successful run", %{
+      dmap_load: dmap_load,
+      ods_load: ods_load
+    } do
+      assert :ok =
+               Ingest.monitor_glue_job_run(
+                 "success_run_id",
+                 [dmap_load.id, ods_load.id],
+                 MockExAws
+               )
+    end
+
+    test "monitoring a error run", %{
+      dmap_load: dmap_load,
+      ods_load: ods_load
+    } do
+      assert {:error, _message} =
+               Ingest.monitor_glue_job_run("error_run_id", [dmap_load.id, ods_load.id], MockExAws)
+    end
+  end
+
+  describe "handle_start_glue_job_error/1" do
+    test "receiving a max concurrency exceeded error" do
+      assert {:snooze, 60} =
+               Ingest.handle_start_glue_job_error(
+                 {:error, {"ConcurrentRunsExceededException", "An error occurred."}}
+               )
+    end
+
+    test "receiving a throttling error" do
+      assert {:snooze, 60} =
+               Ingest.handle_start_glue_job_error(
+                 {:error, {"ThrottlingException", "An error occurred."}}
+               )
+    end
+
+    test "receiving any other error" do
+      assert {:error, _oban_message} =
+               Ingest.handle_start_glue_job_error(
+                 {:error, {"OtherException", "An error occurred."}}
+               )
     end
   end
 end

--- a/ex_cubic_ingestion/test/support/ex_aws.ex
+++ b/ex_cubic_ingestion/test/support/ex_aws.ex
@@ -162,6 +162,14 @@ defmodule MockExAws do
     end
   end
 
+  def request(%{service: :glue, data: %{RunId: "success_run_id"}}, _config_overrides) do
+    {:ok, %{"JobRun" => %{"JobRunState" => "SUCCEEDED"}}}
+  end
+
+  def request(%{service: :glue, data: %{RunId: "error_run_id"}}, _config_overrides) do
+    {:ok, %{"JobRun" => %{"JobRunState" => "ERROR"}}}
+  end
+
   def request(%{service: :glue} = op, _config_overrides) do
     cond do
       Enum.member?(op.headers, {"x-amz-target", "AWSGlue.StartJobRun"}) ->

--- a/ex_cubic_ingestion/test/support/test_fixtures.ex
+++ b/ex_cubic_ingestion/test/support/test_fixtures.ex
@@ -38,7 +38,7 @@ defmodule ExCubicIngestion.TestFixtures do
     dmap_load =
       Repo.insert!(%CubicLoad{
         table_id: dmap_table.id,
-        status: "ready_for_archiving",
+        status: "ready",
         s3_key: "cubic/dmap/sample/20220101.csv",
         s3_modified: ~U[2022-01-01 20:49:50Z],
         s3_size: 197
@@ -47,7 +47,7 @@ defmodule ExCubicIngestion.TestFixtures do
     ods_load =
       Repo.insert!(%CubicLoad{
         table_id: ods_table.id,
-        status: "ready_for_archiving",
+        status: "ready",
         s3_key: ods_snapshot_s3_key,
         s3_modified: ods_snapshot,
         s3_size: 197


### PR DESCRIPTION
After doing a load test on the ingestion process, I ran into an issue with throttling because of Glue's job concurrency limits. This throttling and Oban's speed created many other errors in the process as Oban moved to execute on other jobs in its pipeline.
Initially, I was hoping to be make a determination on when exactly Glue was actually done with a job, so I can start the next one, but upon further investigation Glue does not actually report this in its `Glue.get_job_run()` which contains the latest status of the job. So ultimately, I resulted in using a "low-tech" approach of just giving AWS time to sync its status across systems.