### PR TITLE
[elixir+db] feat: add EDW.SVN_INCIDENT ODS table rec for ingestion.

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/ingest.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/ingest.ex
@@ -159,7 +159,7 @@ defmodule ExCubicIngestion.Workers.Ingest do
   @spec attach_ods_snapshot(map()) :: map()
   defp attach_ods_snapshot(%{partition_columns: partition_columns} = load) do
     if String.starts_with?(load[:s3_key], "cubic/ods_qlik/") do
-      ods_load_rec = CubicOdsLoadSnapshot.get_by!(load_id: load[:id])
+      ods_load_snapshot_rec = CubicOdsLoadSnapshot.get_by!(load_id: load[:id])
 
       # note: order of partitions is intentional
       %{
@@ -167,7 +167,7 @@ defmodule ExCubicIngestion.Workers.Ingest do
         | partition_columns: [
             %{
               "name" => "snapshot",
-              "value" => Calendar.strftime(ods_load_rec.snapshot, "%Y%m%dT%H%M%SZ")
+              "value" => Calendar.strftime(ods_load_snapshot_rec.snapshot, "%Y%m%dT%H%M%SZ")
             }
             | partition_columns
           ]

--- a/ex_cubic_ingestion/priv/repo/migrations/20220801144555_add_svn_incident_ods_table.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20220801144555_add_svn_incident_ods_table.exs
@@ -1,0 +1,25 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddSvnIncidentOdsTable do
+  use Ecto.Migration
+
+  alias ExCubicIngestion.Repo
+  alias ExCubicIngestion.Schema.CubicTable
+  alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
+
+  def up do
+    ods_edw_svn_incident_table_rec = Repo.insert!(%CubicTable{
+      name: "cubic_ods_qlik__edw_svn_incident",
+      s3_prefix: "cubic/ods_qlik/EDW.SVN_INCIDENT/",
+      is_raw: true
+    })
+    Repo.insert!(%CubicOdsTableSnapshot{
+      table_id: ods_edw_svn_incident_table_rec.id,
+      snapshot_s3_key: "cubic/ods_qlik/EDW.SVN_INCIDENT/LOAD00000001.csv.gz"
+    })
+  end
+
+  def down do
+    ods_edw_svn_incident_table_rec = CubicTable.get_by!(name: "cubic_ods_qlik__edw_svn_incident")
+    Repo.delete!(ods_edw_svn_incident_table_rec)
+    Repo.delete!(CubicOdsTableSnapshot.get_by!(table_id: ods_edw_svn_incident_table_rec.id))
+  end
+end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_ods_table_snapshot_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_ods_table_snapshot_test.exs
@@ -5,6 +5,53 @@ defmodule ExCubicIngestion.Schema.CubicOdsTableSnapshotTest do
   alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
   alias ExCubicIngestion.Schema.CubicTable
 
+  describe "get_by!/2" do
+    test "getting only records that are not deleted or exist" do
+      dmap_table =
+        Repo.insert!(%CubicTable{
+          name: "cubic_dmap__sample",
+          s3_prefix: "cubic/dmap/sample/"
+        })
+
+      ods_table =
+        Repo.insert!(%CubicTable{
+          name: "cubic_ods_qlik__sample",
+          s3_prefix: "cubic/ods_qlik/SAMPLE/"
+        })
+
+      ods_table_snapshot =
+        Repo.insert!(%CubicOdsTableSnapshot{
+          table_id: ods_table.id,
+          snapshot: ~U[2022-01-01 20:49:50Z],
+          snapshot_s3_key: "cubic/ods_qlik/SAMPLE/LOAD1.csv"
+        })
+
+      ods_table_deleted =
+        Repo.insert!(%CubicTable{
+          name: "cubic_ods_qlik__deleted",
+          s3_prefix: "cubic/ods_qlik/DELETED/"
+        })
+
+      # inserted deleted record
+      Repo.insert!(%CubicOdsTableSnapshot{
+        table_id: ods_table.id,
+        snapshot: ~U[2022-01-01 20:49:50Z],
+        snapshot_s3_key: "cubic/ods_qlik/SAMPLE/LOAD1.csv",
+        deleted_at: ~U[2022-01-02 20:50:50Z]
+      })
+
+      assert_raise Ecto.NoResultsError, fn ->
+        CubicOdsTableSnapshot.get_by!(table_id: dmap_table.id)
+      end
+
+      assert ods_table_snapshot == CubicOdsTableSnapshot.get_by!(table_id: ods_table.id)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        CubicOdsTableSnapshot.get_by!(table_id: ods_table_deleted.id)
+      end
+    end
+  end
+
   describe "update_snapshot/2" do
     test "update the snapshot value of a table record" do
       ods_table =

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_table_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_table_test.exs
@@ -3,6 +3,33 @@ defmodule ExCubicIngestion.Schema.CubicTableTest do
 
   alias ExCubicIngestion.Schema.CubicTable
 
+  describe "get_by!/2" do
+    test "getting only items that are not deleted or exit" do
+      dmap_table =
+        Repo.insert!(%CubicTable{
+          name: "cubic_dmap__sample",
+          s3_prefix: "cubic/dmap/sample/"
+        })
+
+      # insert deleted record
+      Repo.insert!(%CubicTable{
+        name: "cubic_ods_qlik__sample",
+        s3_prefix: "cubic/ods_qlik/SAMPLE/",
+        deleted_at: ~U[2022-01-01 20:50:50Z]
+      })
+
+      assert dmap_table == CubicTable.get_by!(name: "cubic_dmap__sample")
+
+      assert_raise Ecto.NoResultsError, fn ->
+        CubicTable.get_by!(name: "cubic_ods_qlik__sample")
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        CubicTable.get_by!(name: "cubic_ods_qlik__does_not_exist")
+      end
+    end
+  end
+
   describe "filter_to_existing_prefixes/1" do
     test "providing empty prefixes list" do
       assert [] == CubicTable.filter_to_existing_prefixes([])


### PR DESCRIPTION
This PR adds the SVN_INCIDENT ODS table to be ingested. Table has already been added to the Glue Data Catalog with this deployment: https://github.com/mbta/devops/pull/487