### PR TITLE
[elixir] bug: allow empty datasets to be passed into dmap feed update

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_dmap_feed.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_dmap_feed.ex
@@ -63,6 +63,10 @@ defmodule ExCubicIngestion.Schema.CubicDmapFeed do
   Finds the dataset that was last updated and updates the feed's last updated value
   """
   @spec update_last_updated_from_datasets([CubicDmapDataset.t()], t()) :: t()
+  def update_last_updated_from_datasets([], rec) do
+    rec
+  end
+
   def update_last_updated_from_datasets(dataset_recs, rec) do
     latest_updated_dataset_rec = Enum.max_by(dataset_recs, & &1.last_updated_at, DateTime)
 

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_dmap_feed_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_dmap_feed_test.exs
@@ -36,6 +36,20 @@ defmodule ExCubicIngestion.Schema.CubicDmapFeedTest do
   end
 
   describe "update_last_updated_for_feed/2" do
+    test "no updates are made for empty list of datasets" do
+      dmap_feed =
+        Repo.insert!(%CubicDmapFeed{
+          relative_url: "/controlledresearchusersapi/sample",
+          last_updated_at: ~U[2022-05-16 20:49:50.123456Z]
+        })
+
+      assert ~U[2022-05-16 20:49:50.123456Z] ==
+               CubicDmapFeed.update_last_updated_from_datasets(
+                 [],
+                 dmap_feed
+               ).last_updated_at
+    end
+
     test "update with the latest updated dataset" do
       dmap_feed =
         Repo.insert!(%CubicDmapFeed{


### PR DESCRIPTION
When there is no update to the feed, the worker will pass an empty list of datasets to the update function of DMAP feed. This PR handles this case, so `max_by/3` doesn't error out.