### PR TITLE
[elixir] feat: release tasks to retry archive/error jobs that have failed

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_ingestion.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_ingestion.ex
@@ -53,7 +53,7 @@ defmodule ExCubicIngestion.ProcessIngestion do
   @spec run(map()) :: map()
   defp run(state) do
     # get list of load records that are ready for archive/error, and process them
-    process_loads(CubicLoad.get_status_ready_for())
+    process_loads(CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"]))
 
     # return
     state

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
@@ -166,11 +166,14 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
     Repo.all(query)
   end
 
-  @spec get_status_ready_for :: [t()]
-  def get_status_ready_for do
+  @doc """
+  Get records by a list of statuses.
+  """
+  @spec all_by_status_in([String.t()]) :: [t()]
+  def all_by_status_in(statuses) do
     query =
       from(load in not_deleted(),
-        where: load.status in ["ready_for_archiving", "ready_for_erroring"]
+        where: load.status in ^statuses
       )
 
     Repo.all(query)

--- a/ex_cubic_ingestion/lib/release_tasks/retry_archive_error.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/retry_archive_error.ex
@@ -1,0 +1,46 @@
+defmodule ReleaseTasks.RetryArchiveError do
+  @moduledoc """
+  This release task will retry archive and error jobs for loads that
+  have failed to properly get to the 'archived' and 'errored' status.
+
+  Based on: https://hexdocs.pm/phoenix/releases.html#ecto-migrations-and-custom-commands
+  """
+
+  alias ExCubicIngestion.Repo
+  alias ExCubicIngestion.Schema.CubicLoad
+  alias ExCubicIngestion.Workers.Archive
+  alias ExCubicIngestion.Workers.Error
+
+  @app :ex_cubic_ingestion
+
+  @spec run :: :ok
+  def run do
+    start_app()
+
+    # get all loads that are stuck in 'archiving' and 'erroring'
+    {archiving_loads, erroring_loads} =
+      Enum.split_with(
+        CubicLoad.all_by_status_in(["archiving", "erroring"]),
+        &(&1.status == "archiving")
+      )
+
+    Repo.transaction(fn ->
+      Enum.each(archiving_loads, &Oban.insert!(Archive.new(%{load_rec_id: &1.id})))
+
+      Enum.each(erroring_loads, &Oban.insert!(Error.new(%{load_rec_id: &1.id})))
+    end)
+
+    :ok
+  end
+
+  defp start_app do
+    # loads application configuration
+    Application.load(@app)
+
+    # disables running the full app and just start Oban and Ecto
+    Application.put_env(@app, :start_app_children?, false)
+
+    # starts app
+    Application.ensure_all_started(@app)
+  end
+end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
@@ -160,6 +160,40 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
     end
   end
 
+  describe "all_by_status_in/1" do
+    test "empty list of statuses" do
+      assert [] == CubicLoad.all_by_status_in([])
+    end
+
+    test "get records by a list of statuses", %{
+      table: table
+    } do
+      # insert loads
+      load_1 =
+        Repo.insert!(%CubicLoad{
+          table_id: table.id,
+          status: "ready_for_archiving",
+          s3_key: "cubic/dmap/sample/20220101.csv",
+          s3_modified: ~U[2022-01-01 20:49:50Z],
+          s3_size: 197
+        })
+
+      load_2 =
+        Repo.insert!(%CubicLoad{
+          table_id: table.id,
+          status: "ready_for_erroring",
+          s3_key: "cubic/dmap/sample/20220102.csv",
+          s3_modified: ~U[2022-01-02 20:49:50Z],
+          s3_size: 197
+        })
+
+      actual_loads = CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"])
+
+      assert [load_1.id, load_2.id] ==
+               Enum.sort(Enum.map(actual_loads, & &1.id))
+    end
+  end
+
   describe "update/2" do
     test "setting an 'archived' status", %{
       table: table,

--- a/ex_cubic_ingestion/test/release_tasks/retry_archive_error_test.exs
+++ b/ex_cubic_ingestion/test/release_tasks/retry_archive_error_test.exs
@@ -1,0 +1,56 @@
+defmodule ReleaseTasks.RetryArchiveErrorTest do
+  use ExCubicIngestion.DataCase, async: true
+  use Oban.Testing, repo: ExCubicIngestion.Repo
+
+  alias ExCubicIngestion.Schema.CubicLoad
+  alias ExCubicIngestion.Schema.CubicTable
+  alias ExCubicIngestion.Workers.Archive
+  alias ExCubicIngestion.Workers.Error
+
+  describe "run/1" do
+    test "jobs are queued up" do
+      table =
+        Repo.insert!(%CubicTable{
+          name: "cubic_dmap__sample",
+          s3_prefix: "cubic/dmap/sample/"
+        })
+
+      # insert loads
+      load_1 =
+        Repo.insert!(%CubicLoad{
+          table_id: table.id,
+          status: "archiving",
+          s3_key: "cubic/dmap/sample/20220101.csv",
+          s3_modified: ~U[2022-01-01 20:49:50Z],
+          s3_size: 197
+        })
+
+      load_2 =
+        Repo.insert!(%CubicLoad{
+          table_id: table.id,
+          status: "erroring",
+          s3_key: "cubic/dmap/sample/20220102.csv",
+          s3_modified: ~U[2022-01-02 20:49:50Z],
+          s3_size: 197
+        })
+
+      load_3 =
+        Repo.insert!(%CubicLoad{
+          table_id: table.id,
+          status: "ready",
+          s3_key: "cubic/dmap/sample/20220103.csv",
+          s3_modified: ~U[2022-01-03 20:49:50Z],
+          s3_size: 197
+        })
+
+      assert :ok = ReleaseTasks.RetryArchiveError.run()
+
+      assert_enqueued(worker: Archive, args: %{load_rec_id: load_1.id})
+
+      assert_enqueued(worker: Error, args: %{load_rec_id: load_2.id})
+
+      refute_enqueued(worker: Archive, args: %{load_rec_id: load_3.id})
+      refute_enqueued(worker: Error, args: %{load_rec_id: load_3.id})
+    end
+  end
+end


### PR DESCRIPTION
This PR enables retries of Archive and Error jobs for loads that are stuck in 'archiving' and 'erroring' due to errors from last time the job ran.


There are 2 options for testing this locally:
Note: If you need to setup your local environment, refer to [README.md](https://github.com/mbta/data_platform/blob/main/README.md).
1. Through tests:
```sh
cd ex_cubic_ingestion
mix test
```
2. Through application:
```sh
cd ex_cubic_ingestion
mix release
_build/dev/rel/ex_cubic_ingestion/bin/ex_cubic_ingestion start
# in new terminal window
_build/dev/rel/ex_cubic_ingestion/bin/ex_cubic_ingestion eval "ReleaseTasks.RetryArchiveError.run()"
```