### PR TITLE
[elixir] feat: add fetch dmap release task so we can refetch dataset

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_dmap_dataset.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_dmap_dataset.ex
@@ -84,6 +84,18 @@ defmodule ExCubicIngestion.Schema.CubicDmapDataset do
     recs_with_url
   end
 
+  @doc """
+
+  """
+  @spec iso_extended_to_datetime(String.t()) :: DateTime.t() | nil
+  def iso_extended_to_datetime(""), do: nil
+
+  def iso_extended_to_datetime(iso_extended) do
+    iso_extended
+    |> Timex.parse!("{ISO:Extended}")
+    |> DateTime.from_naive!("Etc/UTC")
+  end
+
   @spec upsert_from_dataset(map(), CubicDmapFeed.t()) :: t()
   defp upsert_from_dataset(dataset, feed_rec) do
     Repo.insert!(
@@ -98,12 +110,5 @@ defmodule ExCubicIngestion.Schema.CubicDmapDataset do
       on_conflict: [set: [last_updated_at: iso_extended_to_datetime(dataset["last_updated"])]],
       conflict_target: :identifier
     )
-  end
-
-  @spec iso_extended_to_datetime(String.t()) :: DateTime.t()
-  defp iso_extended_to_datetime(iso_extended) do
-    iso_extended
-    |> Timex.parse!("{ISO:Extended}")
-    |> DateTime.from_naive!("Etc/UTC")
   end
 end

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_dmap_dataset.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_dmap_dataset.ex
@@ -85,11 +85,9 @@ defmodule ExCubicIngestion.Schema.CubicDmapDataset do
   end
 
   @doc """
-
+  Converts an ISO formatted datetime String to Datetime
   """
-  @spec iso_extended_to_datetime(String.t()) :: DateTime.t() | nil
-  def iso_extended_to_datetime(""), do: nil
-
+  @spec iso_extended_to_datetime(String.t()) :: DateTime.t()
   def iso_extended_to_datetime(iso_extended) do
     iso_extended
     |> Timex.parse!("{ISO:Extended}")

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/fetch_dmap.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/fetch_dmap.ex
@@ -50,8 +50,8 @@ defmodule ExCubicIngestion.Workers.FetchDmap do
   Construct the full URL to the feed, applying some overriding logic for
   last updated (if passed in).
   """
-  @spec construct_feed_url(CubicDmapFeed.t(), DateTime.t() | nil) :: String.t()
-  def construct_feed_url(feed_rec, last_updated \\ nil) do
+  @spec construct_feed_url(CubicDmapFeed.t(), String.t() | nil) :: String.t()
+  def construct_feed_url(feed_rec, last_updated) do
     dmap_base_url = Application.fetch_env!(:ex_cubic_ingestion, :dmap_base_url)
 
     dmap_api_key = Application.fetch_env!(:ex_cubic_ingestion, :dmap_api_key)
@@ -59,7 +59,7 @@ defmodule ExCubicIngestion.Workers.FetchDmap do
     last_updated =
       cond do
         not is_nil(last_updated) ->
-          last_updated
+          CubicDmapDataset.iso_extended_to_datetime(last_updated)
 
         not is_nil(feed_rec.last_updated_at) ->
           DateTime.add(feed_rec.last_updated_at, 1, :microsecond)
@@ -82,7 +82,7 @@ defmodule ExCubicIngestion.Workers.FetchDmap do
   Using the feed record to construct a URL and get the contents containing the dataset
   information. Also, checks that datasets are valid an filters out invalid ones.
   """
-  @spec get_feed_datasets(CubicDmapFeed.t(), DateTime.t(), module()) :: [map()]
+  @spec get_feed_datasets(CubicDmapFeed.t(), String.t() | nil, module()) :: [map()]
   def get_feed_datasets(feed_rec, last_updated, lib_httpoison) do
     %HTTPoison.Response{status_code: 200, body: body} =
       lib_httpoison.get!(construct_feed_url(feed_rec, last_updated))

--- a/ex_cubic_ingestion/lib/release_tasks/application.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/application.ex
@@ -1,0 +1,24 @@
+defmodule ReleaseTasks.Application do
+  @moduledoc """
+  Module containing helper functions for dealing with the application.
+  """
+
+  @app :ex_cubic_ingestion
+
+  @spec start :: :ok
+  @doc """
+  Starts application without the GenServers.
+  """
+  def start do
+    # loads application configuration
+    Application.load(@app)
+
+    # disables running the full app and just start Oban and Ecto
+    Application.put_env(@app, :start_app_children?, false)
+
+    # starts app
+    Application.ensure_all_started(@app)
+
+    :ok
+  end
+end

--- a/ex_cubic_ingestion/lib/release_tasks/fetch_dmap.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/fetch_dmap.ex
@@ -1,0 +1,28 @@
+defmodule ReleaseTasks.FetchDmap do
+  @moduledoc """
+  Inserts a FetchDmap job for the DMAP feed specified, and the minimum
+  last updated datetime that datasets should be fetched for.
+
+  Based on: https://hexdocs.pm/phoenix/releases.html#ecto-migrations-and-custom-commands
+  """
+
+  alias ExCubicIngestion.Workers.FetchDmap
+
+  @spec run(map()) :: :ok
+  @doc """
+  Inserts a FetchDmap job to get the specified feed and get datasets that were
+  updated after the last updated parameter.
+  """
+  def run(%{feed_id: feed_id, last_updated: %DateTime{} = last_updated}) do
+    ReleaseTasks.Application.start()
+
+    Oban.insert(
+      FetchDmap.new(%{
+        feed_id: feed_id,
+        last_updated: last_updated
+      })
+    )
+
+    :ok
+  end
+end

--- a/ex_cubic_ingestion/lib/release_tasks/fetch_dmap.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/fetch_dmap.ex
@@ -14,7 +14,7 @@ defmodule ReleaseTasks.FetchDmap do
   updated after the last updated parameter.
   """
   def run(%{feed_id: feed_id, last_updated: %DateTime{} = last_updated}) do
-    ReleaseTasks.Application.start()
+    ReleaseTasks.Utilities.start_app()
 
     Oban.insert(
       FetchDmap.new(%{

--- a/ex_cubic_ingestion/lib/release_tasks/retry_archive_error.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/retry_archive_error.ex
@@ -11,11 +11,13 @@ defmodule ReleaseTasks.RetryArchiveError do
   alias ExCubicIngestion.Workers.Archive
   alias ExCubicIngestion.Workers.Error
 
-  @app :ex_cubic_ingestion
-
   @spec run :: :ok
+  @doc """
+  Inserts an Archive/Error job for each load with the status "archiving",
+  "archived_unknown", "erroring", and "errored_unknown".
+  """
   def run do
-    start_app()
+    ReleaseTasks.Application.start()
 
     # get all loads that are stuck in 'archiving' and 'erroring'
     {archiving_loads, erroring_loads} =
@@ -36,16 +38,5 @@ defmodule ReleaseTasks.RetryArchiveError do
     end)
 
     :ok
-  end
-
-  defp start_app do
-    # loads application configuration
-    Application.load(@app)
-
-    # disables running the full app and just start Oban and Ecto
-    Application.put_env(@app, :start_app_children?, false)
-
-    # starts app
-    Application.ensure_all_started(@app)
   end
 end

--- a/ex_cubic_ingestion/lib/release_tasks/retry_archive_error.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/retry_archive_error.ex
@@ -17,7 +17,7 @@ defmodule ReleaseTasks.RetryArchiveError do
   "archived_unknown", "erroring", and "errored_unknown".
   """
   def run do
-    ReleaseTasks.Application.start()
+    ReleaseTasks.Utilities.start_app()
 
     # get all loads that are stuck in 'archiving' and 'erroring'
     {archiving_loads, erroring_loads} =

--- a/ex_cubic_ingestion/lib/release_tasks/schedule_dmap.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/schedule_dmap.ex
@@ -13,7 +13,7 @@ defmodule ReleaseTasks.ScheduleDmap do
   """
   @spec run(map()) :: :ok
   def run(args) do
-    ReleaseTasks.Application.start()
+    ReleaseTasks.Utilities.start_app()
 
     # add a new schedule dmap job
     Oban.insert!(ScheduleDmap.new(args))

--- a/ex_cubic_ingestion/lib/release_tasks/schedule_dmap.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/schedule_dmap.ex
@@ -8,23 +8,12 @@ defmodule ReleaseTasks.ScheduleDmap do
 
   alias ExCubicIngestion.Workers.ScheduleDmap
 
-  @app :ex_cubic_ingestion
-
   @doc """
-  Start the application without the GenServers, so we don't have competing
-  processes for querying the incoming bucket, and then inserting a ScheduleDMAP
-  job for Oban to process.
+  Inserts a ScheduleDMAP job for Oban to process.
   """
   @spec run(map()) :: :ok
   def run(args) do
-    # loads application configuration
-    Application.load(@app)
-
-    # disables running the full app and just start Oban and Ecto
-    Application.put_env(@app, :start_app_children?, false)
-
-    # starts app
-    Application.ensure_all_started(@app)
+    ReleaseTasks.Application.start()
 
     # add a new schedule dmap job
     Oban.insert!(ScheduleDmap.new(args))

--- a/ex_cubic_ingestion/lib/release_tasks/utilities.ex
+++ b/ex_cubic_ingestion/lib/release_tasks/utilities.ex
@@ -1,15 +1,15 @@
-defmodule ReleaseTasks.Application do
+defmodule ReleaseTasks.Utilities do
   @moduledoc """
-  Module containing helper functions for dealing with the application.
+  Module containing functions with commonly-used functionality.
   """
 
   @app :ex_cubic_ingestion
 
-  @spec start :: :ok
+  @spec start_app :: :ok
   @doc """
-  Starts application without the GenServers.
+  Starts 'ex_cubic_ingestion' application without the GenServers.
   """
-  def start do
+  def start_app do
     # loads application configuration
     Application.load(@app)
 

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/process_incoming_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/process_incoming_test.exs
@@ -49,7 +49,8 @@ defmodule ExCubicIngestion.ProcessIncomingTest do
 
       :ok = ProcessIncoming.run(state)
 
-      [ods_load_1, ods_load_2, dmap_load_1, dmap_load_2] = Repo.all(CubicLoad)
+      [ods_load_1, ods_load_2, dmap_load_1, dmap_load_2] =
+        Enum.sort_by(Repo.all(CubicLoad), & &1.id)
 
       assert %CubicLoad{
                s3_key: "cubic/ods_qlik/SAMPLE/LOAD1.csv",

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/fetch_dmap_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/fetch_dmap_test.exs
@@ -36,7 +36,7 @@ defmodule ExCubicIngestion.Workers.FetchDmapTest do
       dmap_api_key = Application.fetch_env!(:ex_cubic_ingestion, :dmap_api_key)
 
       assert "#{dmap_base_url}#{dmap_feed_relative_url}?apikey=#{dmap_api_key}" ==
-               FetchDmap.construct_feed_url(dmap_feed)
+               FetchDmap.construct_feed_url(dmap_feed, nil)
     end
 
     test "feed with a last updated timestamp" do
@@ -53,7 +53,7 @@ defmodule ExCubicIngestion.Workers.FetchDmapTest do
       dmap_api_key = Application.fetch_env!(:ex_cubic_ingestion, :dmap_api_key)
 
       assert "#{dmap_base_url}#{dmap_feed_relative_url}?apikey=#{dmap_api_key}&last_updated=2022-05-22T20:49:50.123457" ==
-               FetchDmap.construct_feed_url(dmap_feed)
+               FetchDmap.construct_feed_url(dmap_feed, nil)
     end
 
     test "feed with last updated passed in" do
@@ -72,7 +72,7 @@ defmodule ExCubicIngestion.Workers.FetchDmapTest do
       dmap_api_key = Application.fetch_env!(:ex_cubic_ingestion, :dmap_api_key)
 
       assert "#{dmap_base_url}#{dmap_feed_relative_url}?apikey=#{dmap_api_key}&last_updated=2022-05-01T10:49:50.123456" ==
-               FetchDmap.construct_feed_url(dmap_feed, last_updated)
+               FetchDmap.construct_feed_url(dmap_feed, DateTime.to_string(last_updated))
     end
   end
 
@@ -88,7 +88,11 @@ defmodule ExCubicIngestion.Workers.FetchDmapTest do
 
       assert ["sample_20220517", "sample_20220518"] =
                Enum.map(
-                 FetchDmap.get_feed_datasets(dmap_feed, last_updated, MockHTTPoison),
+                 FetchDmap.get_feed_datasets(
+                   dmap_feed,
+                   DateTime.to_string(last_updated),
+                   MockHTTPoison
+                 ),
                  & &1["dataset_id"]
                )
     end

--- a/ex_cubic_ingestion/test/release_tasks/fetch_dmap_test.exs
+++ b/ex_cubic_ingestion/test/release_tasks/fetch_dmap_test.exs
@@ -1,0 +1,22 @@
+defmodule ReleaseTasks.FetchDmapTest do
+  use ExCubicIngestion.DataCase, async: true
+  use Oban.Testing, repo: ExCubicIngestion.Repo
+
+  alias ExCubicIngestion.Schema.CubicDmapFeed
+  alias ExCubicIngestion.Workers.FetchDmap
+
+  describe "run/1" do
+    test "job was queued up" do
+      dmap_feed =
+        Repo.insert!(%CubicDmapFeed{
+          relative_url: "/controlledresearchusersapi/sample"
+        })
+
+      args = %{feed_id: dmap_feed.id, last_updated: ~U[2022-01-01 10:49:50.123456Z]}
+
+      assert :ok = ReleaseTasks.FetchDmap.run(args)
+
+      assert_enqueued(worker: FetchDmap, args: args)
+    end
+  end
+end


### PR DESCRIPTION
This PR will allow us to re-fetch a certain feed even though it might have been fetched in the past. We'll be able to pass a date that will be used to narrow down the datasets to only the ones that have been updated since that date.

Planning on running with something like this:
```sh
_build/dev/rel/ex_cubic_ingestion/bin/ex_cubic_ingestion eval "ReleaseTasks.FetchDmap.run(%{feed_id: 1, last_updated: ~U[2022-06-20 10:49:50.123456Z]})"
```