### PR TITLE
[elixir] feat: set pool size for dev.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,7 @@ DB_PORT=5432
 DB_NAME=data_platform
 DB_USER=postgres
 DB_PASSWORD=postgres
+DB_POOL_SIZE=10
 
 # buckets
 S3_BUCKET_OPERATIONS=

--- a/ex_cubic_ingestion/config/runtime.exs
+++ b/ex_cubic_ingestion/config/runtime.exs
@@ -6,7 +6,9 @@ config :ex_cubic_ingestion, ExCubicIngestion.Repo,
   hostname: System.get_env("DB_HOST"),
   password: System.get_env("DB_PASSWORD"),
   port: "DB_PORT" |> System.get_env("5432") |> String.to_integer(),
-  configure: {ExCubicIngestion.Repo, :before_connect, []}
+  configure: {ExCubicIngestion.Repo, :before_connect, []},
+  # default to 10
+  pool_size: "DB_POOL_SIZE" |> System.get_env("10") |> String.to_integer()
 
 # for testing, we'd like to change the database
 if config_env() == :test do


### PR DESCRIPTION
In an attempt to narrow down why the ECS service keeps staring new containers, I'd like to make sure the a crash is not happening because of an aggressive number of connections are going over the limit. See for RDS limits: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections