### PR TITLE
[db] add indexes for load tables

### DIFF
--- a/ex_cubic_ingestion/priv/repo/migrations/20220725185622_add_indexes_for_loads.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20220725185622_add_indexes_for_loads.exs
@@ -1,0 +1,15 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddIndexesForLoads do
+  use Ecto.Migration
+
+  def up do
+    create index("cubic_loads", [:status, :deleted_at])
+    create index("cubic_loads", [:s3_key, :s3_modified, :deleted_at])
+    create index("cubic_ods_load_snapshots", [:load_id, :deleted_at])
+  end
+
+  def down do
+    drop index("cubic_ods_load_snapshots", [:load_id, :deleted_at])
+    drop index("cubic_loads", [:s3_key, :s3_modified, :deleted_at])
+    drop index("cubic_loads", [:status, :deleted_at])
+  end
+end


### PR DESCRIPTION
This PR adds some indexes to address database performance issues and assist in ruling out slow queries as being the cause of ECS container restarts, as indicated here. A quick explanation of each index below:

`create index("cubic_loads", [:status, :deleted_at])`
There are various areas where we query the loads table by status for further pipeline processing.

`create index("cubic_loads", [:s3_key, :s3_modified, :deleted_at])`
We query the loads table by `s3_key` and `s3_modified` to see if we might have already added a record for the S3 object.

`create index("cubic_ods_load_snapshots", [:load_id, :deleted_at])`
Before we archive or error, we query the load snapshots by the load_id to determine how to store the load in the respective buckets.