### PR TITLE
[elixir] feat: adjust to querying loads with only recent s3 objects

### DIFF
--- a/ex_cubic_ingestion/lib/ex_aws/helpers.ex
+++ b/ex_cubic_ingestion/lib/ex_aws/helpers.ex
@@ -3,8 +3,6 @@ defmodule ExAws.Helpers do
   Central place for useful functions that do ExAws work.
   """
 
-  require Logger
-
   @doc """
   Performs checks, before copying the source object to a destination object
   and deleting the source object (moving).

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_incoming.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_incoming.ex
@@ -71,7 +71,11 @@ defmodule ExCubicIngestion.ProcessIncoming do
         prefix: "#{incoming_prefix}#{table_prefix}",
         lib_ex_aws: state.lib_ex_aws
       )
-      |> Enum.filter(&Validators.valid_s3_object?(&1))
+      # filter s3 objects to only acceptable ones
+      |> Enum.filter(fn s3_object ->
+        Validators.valid_s3_object?(s3_object) and
+          Validators.recently_created_s3_object?(s3_object)
+      end)
       |> Enum.map(fn object ->
         %{object | key: String.replace_prefix(object[:key], incoming_prefix, "")}
       end)

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
@@ -103,8 +103,8 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
   """
   @spec insert_from_object_with_table(map(), CubicTable.t()) :: t()
   def insert_from_object_with_table(object, table) do
-    last_modified = parse_and_drop_msec(object[:last_modified])
-    size = String.to_integer(object[:size])
+    last_modified = parse_and_drop_msec(object.last_modified)
+    size = String.to_integer(object.size)
 
     status =
       if size > 0 do
@@ -116,21 +116,24 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
     Repo.insert!(%__MODULE__{
       table_id: table.id,
       status: status,
-      s3_key: object[:key],
+      s3_key: object.key,
       s3_modified: last_modified,
       s3_size: size,
       is_raw: table.is_raw
     })
   end
 
+  @doc """
+  For a list of S3 objects, get all the possible matching load records.
+  """
   @spec get_by_objects(list()) :: [t()]
   def get_by_objects(objects) do
     # put together filters based on the object info
     filters =
       Enum.map(objects, fn object ->
-        last_modified = parse_and_drop_msec(object[:last_modified])
+        last_modified = parse_and_drop_msec(object.last_modified)
 
-        {object[:key], last_modified}
+        {object.key, last_modified}
       end)
 
     # we only want to query if we have filters because otherwise the query will the return
@@ -154,8 +157,8 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
 
   @spec not_added(map(), list()) :: boolean()
   def not_added(load_object, load_recs) do
-    key = load_object[:key]
-    last_modified = parse_and_drop_msec(load_object[:last_modified])
+    key = load_object.key
+    last_modified = parse_and_drop_msec(load_object.last_modified)
 
     not Enum.any?(
       load_recs,

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/validators.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/validators.ex
@@ -25,9 +25,26 @@ defmodule ExCubicIngestion.Validators do
     Enum.all?(key_list, &Map.has_key?(map, &1))
   end
 
+  @doc """
+  S3 object is created in the last 24 hours
+  """
+  @spec recently_created_s3_object?(map()) :: boolean()
+  def recently_created_s3_object?(%{last_modified: last_modified}) do
+    {:ok, last_modified_dt, _offset} = DateTime.from_iso8601(last_modified)
+
+    DateTime.compare(last_modified_dt, DateTime.add(DateTime.utc_now(), -86_400)) == :gt
+  end
+
+  def recently_created_s3_object?(%{}) do
+    false
+  end
+
+  @doc """
+  Only valid if the name ends with '.csv.gz' or '.csv' and has a size specified
+  """
   @spec valid_s3_object?(map()) :: boolean()
   def valid_s3_object?(%{key: key, size: _size}) do
-    not String.ends_with?(key, "/")
+    String.ends_with?(key, ".csv.gz") or String.ends_with?(key, ".csv")
   end
 
   def valid_s3_object?(%{}) do

--- a/ex_cubic_ingestion/test/support/ex_aws_data.ex
+++ b/ex_cubic_ingestion/test/support/ex_aws_data.ex
@@ -10,11 +10,13 @@ defmodule MockExAws.Data do
   def load_objects(key_starts_with \\ "") do
     incoming_prefix = Application.fetch_env!(:ex_cubic_ingestion, :s3_bucket_prefix_incoming)
 
+    utc_now = DateTime.utc_now()
+
     objects = [
       %{
         e_tag: "\"ghi123\"",
         key: "#{incoming_prefix}cubic/dmap/sample/20220101.csv",
-        last_modified: "2022-01-01T20:49:50.000Z",
+        last_modified: dt_adjust_and_format(utc_now, -3600),
         owner: nil,
         size: "197",
         storage_class: "STANDARD"
@@ -22,7 +24,7 @@ defmodule MockExAws.Data do
       %{
         e_tag: "\"jkl123\"",
         key: "#{incoming_prefix}cubic/dmap/sample/20220102.csv",
-        last_modified: "2022-01-02T20:49:50.000Z",
+        last_modified: dt_adjust_and_format(utc_now, -3000),
         owner: nil,
         size: "197",
         storage_class: "STANDARD"
@@ -30,7 +32,7 @@ defmodule MockExAws.Data do
       %{
         e_tag: "\"abc123\"",
         key: "#{incoming_prefix}cubic/ods_qlik/SAMPLE/LOAD1.csv",
-        last_modified: "2022-02-08T20:49:50.000Z",
+        last_modified: dt_adjust_and_format(utc_now, -2400),
         owner: nil,
         size: "197",
         storage_class: "STANDARD"
@@ -38,7 +40,7 @@ defmodule MockExAws.Data do
       %{
         e_tag: "\"def123\"",
         key: "#{incoming_prefix}cubic/ods_qlik/SAMPLE/LOAD2.csv",
-        last_modified: "2022-02-08T20:50:50.000Z",
+        last_modified: dt_adjust_and_format(utc_now, -1800),
         owner: nil,
         size: "123",
         storage_class: "STANDARD"
@@ -49,14 +51,10 @@ defmodule MockExAws.Data do
   end
 
   @doc """
-  Helper function to eliminate duplication in tests that don't care about the bucket prefix.
+  For a give datetime, adjust it by with the seconds and format it as an S3 timestamp.
   """
-  @spec load_objects_without_bucket_prefix(String.t()) :: [map()]
-  def load_objects_without_bucket_prefix(key_starts_with \\ "") do
-    incoming_prefix = Application.fetch_env!(:ex_cubic_ingestion, :s3_bucket_prefix_incoming)
-
-    Enum.map(load_objects(key_starts_with), fn object ->
-      %{object | key: String.replace_prefix(object[:key], incoming_prefix, "")}
-    end)
+  @spec dt_adjust_and_format(DateTime.t(), Integer.t()) :: String.t()
+  def dt_adjust_and_format(dt, seconds) do
+    dt |> DateTime.add(seconds, :second) |> Calendar.strftime("%Y-%m-%dT%H:%M:%S.000Z")
   end
 end


### PR DESCRIPTION
This PR address an issues where a list of s3 objects that is checked against the `cubic_loads` table is rather large and therefore the query is very large. With this PR, we shrink the list down to only objects from the last 24 hours. The objects will have 24 hours to make it through the ingestion process. If the object is in the Incoming bucket for longer than 24 hours, then something has gone wrong.

In our case, the cause of this issue was the ECS task shutting down before the job was finished, and hence leaving loads in  the 'ingesting' status. According to [this](https://github.com/sorentwo/oban/issues/430) Oban should update its state and fail the jobs on a KILL command, but I suspect that the ECS task can't communicate with the DB due to overload.

Overall, this is an improvement to the process and keeps the pipeline steady. 

We will address loads stuck in 'ingesting' in a similar way to [this PR](https://github.com/mbta/data_platform/pull/62), which addresses loads stuck in 'archiving' and 'erroring'.