### PR TITLE
[elixir] feat: limit how many ready loads to start ingestion for

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_ingestion.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_ingestion.ex
@@ -53,7 +53,9 @@ defmodule ExCubicIngestion.ProcessIngestion do
   @spec run(map()) :: map()
   defp run(state) do
     # get list of load records that are ready for archive/error, and process them
-    process_loads(CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"]))
+    ["ready_for_archiving", "ready_for_erroring"]
+    |> CubicLoad.all_by_status_in()
+    |> process_loads()
 
     # return
     state

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
@@ -136,15 +136,48 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
     })
   end
 
-  @spec get_status_ready :: [t()]
-  def get_status_ready do
-    query =
-      from(load in not_deleted(),
-        where: load.status == "ready",
-        order_by: [load.s3_modified, load.s3_key]
-      )
+  @doc """
+  Get loads with the 'ready' status by getting all the active tables and
+  querying for the first {limit} loads by table. For ODS, because there might be a
+  Qlik restart between the 'ready' and 'ingesting' status, we should check to make
+  sure we only start since the last snapshot load's s3_modified. Because of this
+  logic, some 'ready' loads will be left behind. That's because they will be
+  pointing to non-existing objects (Note: Qlik removes all objects on a restart).
+  """
+  @spec get_status_ready(integer()) :: [t()]
+  def get_status_ready(limit \\ 100) do
+    # we need to get 'ready' loads only for active tables
+    CubicTable.all_with_ods_table_snapshot()
+    |> Enum.map(fn {table_rec, ods_table_snapshot_rec} ->
+      # get the last load with snapshot key
+      last_snapshot_load_rec =
+        if not is_nil(ods_table_snapshot_rec) do
+          Repo.one(
+            from(load in not_deleted(),
+              where: load.s3_key == ^ods_table_snapshot_rec.snapshot_s3_key,
+              order_by: [desc: load.s3_modified],
+              limit: 1
+            )
+          )
+        end
 
-    Repo.all(query)
+      # query for 'ready' loads, with limit
+      ready_loads =
+        from(load in not_deleted(),
+          where: load.status == "ready" and load.table_id == ^table_rec.id,
+          order_by: [load.s3_modified, load.s3_key],
+          limit: ^limit
+        )
+
+      # if we know the last snapshot load, then filter down to 'ready' loads
+      # after the snapshot
+      if is_nil(last_snapshot_load_rec) do
+        ready_loads
+      else
+        from(load in ready_loads, where: load.s3_modified >= ^last_snapshot_load_rec.s3_modified)
+      end
+    end)
+    |> Enum.flat_map(&Repo.all(&1))
   end
 
   @doc """

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
@@ -183,11 +183,13 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
   @doc """
   Get records by a list of statuses.
   """
-  @spec all_by_status_in([String.t()]) :: [t()]
-  def all_by_status_in(statuses) do
+  @spec all_by_status_in([String.t()], integer()) :: [t()]
+  def all_by_status_in(statuses, limit \\ 1000) do
     query =
       from(load in not_deleted(),
-        where: load.status in ^statuses
+        where: load.status in ^statuses,
+        order_by: load.id,
+        limit: ^limit
       )
 
     Repo.all(query)

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_table.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_table.ex
@@ -93,7 +93,8 @@ defmodule ExCubicIngestion.Schema.CubicTable do
       from(table in not_deleted(),
         left_join: ods_table_snapshot in CubicOdsTableSnapshot,
         on: table.id == ods_table_snapshot.table_id,
-        select: {table, ods_table_snapshot}
+        select: {table, ods_table_snapshot},
+        order_by: table.id
       )
     )
   end

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_table.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_table.ex
@@ -8,6 +8,7 @@ defmodule ExCubicIngestion.Schema.CubicTable do
   import Ecto.Query
 
   alias ExCubicIngestion.Repo
+  alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
 
   @derive {Jason.Encoder,
            only: [
@@ -81,5 +82,19 @@ defmodule ExCubicIngestion.Schema.CubicTable do
         {prefix, table}
       end
     end
+  end
+
+  @doc """
+  Get all active tables, including ODS snapshot for ODS tables.
+  """
+  @spec all_with_ods_table_snapshot :: [{t(), CubicOdsTableSnapshot.t()}]
+  def all_with_ods_table_snapshot do
+    Repo.all(
+      from(table in not_deleted(),
+        left_join: ods_table_snapshot in CubicOdsTableSnapshot,
+        on: table.id == ods_table_snapshot.table_id,
+        select: {table, ods_table_snapshot}
+      )
+    )
   end
 end

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/start_ingestion.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/start_ingestion.ex
@@ -73,6 +73,8 @@ defmodule ExCubicIngestion.StartIngestion do
     ready_loads
     |> chunk_loads(@max_num_of_loads, @max_size_of_loads)
     |> Enum.each(&process_loads/1)
+
+    :ok
   end
 
   @spec chunk_loads([CubicLoad.t()], integer(), integer()) :: [[CubicLoad.t(), ...]]

--- a/ex_cubic_ingestion/priv/repo/migrations/20220901184846_add_index_for_load_status_table_id.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20220901184846_add_index_for_load_status_table_id.exs
@@ -1,0 +1,11 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddIndexForLoadStatusTableId do
+  use Ecto.Migration
+
+  def up do
+    create index("cubic_loads", [:status, :table_id, :deleted_at])
+  end
+
+  def down do
+    drop index("cubic_loads", [:status, :table_id, :deleted_at])
+  end
+end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
@@ -184,7 +184,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
     end
   end
 
-  describe "all_by_status_in/1" do
+  describe "all_by_status_in/2" do
     test "empty list of statuses" do
       assert [] == CubicLoad.all_by_status_in([])
     end
@@ -211,10 +211,31 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
           s3_size: 197
         })
 
-      actual_loads = CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"])
+      assert [load_1, load_2] ==
+               CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"])
+    end
 
-      assert [load_1.id, load_2.id] ==
-               Enum.sort(Enum.map(actual_loads, & &1.id))
+    test "limiting the number of records returned", %{
+      table: table
+    } do
+      # insert loads
+      Repo.insert!(%CubicLoad{
+        table_id: table.id,
+        status: "ready_for_archiving",
+        s3_key: "cubic/dmap/sample/20220101.csv.gz",
+        s3_modified: ~U[2022-01-01 20:49:50Z],
+        s3_size: 197
+      })
+
+      Repo.insert!(%CubicLoad{
+        table_id: table.id,
+        status: "ready_for_archiving",
+        s3_key: "cubic/dmap/sample/20220102.csv.gz",
+        s3_modified: ~U[2022-01-02 20:49:50Z],
+        s3_size: 197
+      })
+
+      assert 1 == length(CubicLoad.all_by_status_in(["ready_for_archiving"], 1))
     end
   end
 

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
@@ -63,7 +63,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
       # add a new object
       load_objects = [
         %{
-          key: "cubic/dmap/sample/20220103.csv",
+          key: "cubic/dmap/sample/20220103.csv.gz",
           last_modified: MockExAws.Data.dt_adjust_and_format(utc_now, -2400),
           size: "197"
         }
@@ -74,7 +74,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
       assert {:ok,
               [
                 %CubicLoad{
-                  s3_key: "cubic/dmap/sample/20220103.csv"
+                  s3_key: "cubic/dmap/sample/20220103.csv.gz"
                 }
               ]} = CubicLoad.insert_new_from_objects_with_table(load_objects, table)
     end
@@ -136,7 +136,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
           is_raw: true
         })
 
-      ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv"
+      ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv.gz"
       ods_snapshot = ~U[2022-01-01 20:49:50Z]
 
       Repo.insert!(%CubicOdsTableSnapshot{
@@ -159,7 +159,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
       Repo.insert!(%CubicLoad{
         table_id: ods_table.id,
         status: "ready",
-        s3_key: "cubic/ods_qlik/SAMPLE/LOAD2.csv",
+        s3_key: "cubic/ods_qlik/SAMPLE/LOAD2.csv.gz",
         s3_modified: ~U[2022-01-02 20:49:50Z],
         s3_size: 197,
         is_raw: true
@@ -173,7 +173,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
         Repo.insert!(%CubicLoad{
           table_id: ods_table.id,
           status: "ready",
-          s3_key: "cubic/ods_qlik/SAMPLE/LOAD1.csv",
+          s3_key: "cubic/ods_qlik/SAMPLE/LOAD1.csv.gz",
           s3_modified: ~U[2022-01-03 20:49:50Z],
           s3_size: 197,
           is_raw: true

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
@@ -4,6 +4,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
   import Ecto.Changeset
 
   alias ExCubicIngestion.Schema.CubicLoad
+  alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
   alias ExCubicIngestion.Schema.CubicTable
 
   setup do
@@ -111,7 +112,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
   end
 
   describe "get_status_ready/0" do
-    test "getting load records with the status 'ready'", %{
+    test "getting non-ODS 'ready' loads", %{
       table: table,
       load_objects: load_objects
     } do
@@ -124,6 +125,62 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
 
       # assert that the last record inserted comes back
       assert rest_new_load_recs == CubicLoad.get_status_ready()
+    end
+
+    test "getting ODS 'ready' loads" do
+      # insert ODS table and snapshot
+      ods_table =
+        Repo.insert!(%CubicTable{
+          name: "cubic_ods_qlik__sample",
+          s3_prefix: "cubic/ods_qlik/SAMPLE/",
+          is_raw: true
+        })
+
+      ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv"
+      ods_snapshot = ~U[2022-01-01 20:49:50Z]
+
+      Repo.insert!(%CubicOdsTableSnapshot{
+        table_id: ods_table.id,
+        snapshot: ods_snapshot,
+        snapshot_s3_key: ods_snapshot_s3_key
+      })
+
+      # insert loads
+      ods_load =
+        Repo.insert!(%CubicLoad{
+          table_id: ods_table.id,
+          status: "ready",
+          s3_key: ods_snapshot_s3_key,
+          s3_modified: ods_snapshot,
+          s3_size: 197,
+          is_raw: true
+        })
+
+      Repo.insert!(%CubicLoad{
+        table_id: ods_table.id,
+        status: "ready",
+        s3_key: "cubic/ods_qlik/SAMPLE/LOAD2.csv",
+        s3_modified: ~U[2022-01-02 20:49:50Z],
+        s3_size: 197,
+        is_raw: true
+      })
+
+      # only get the first load because of limit
+      assert [ods_load] == CubicLoad.get_status_ready(1)
+
+      # add new snapshot load
+      new_ods_load =
+        Repo.insert!(%CubicLoad{
+          table_id: ods_table.id,
+          status: "ready",
+          s3_key: "cubic/ods_qlik/SAMPLE/LOAD1.csv",
+          s3_modified: ~U[2022-01-03 20:49:50Z],
+          s3_size: 197,
+          is_raw: true
+        })
+
+      # ignoring loads prior to this last snapshot load
+      assert [new_ods_load] == CubicLoad.get_status_ready()
     end
   end
 

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_table_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_table_test.exs
@@ -91,7 +91,7 @@ defmodule ExCubicIngestion.Schema.CubicTableTest do
       ods_table_id = ods_table.id
 
       # insert ODS table
-      ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv"
+      ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv.gz"
 
       ods_table_snapshot =
         Repo.insert!(%CubicOdsTableSnapshot{
@@ -106,12 +106,9 @@ defmodule ExCubicIngestion.Schema.CubicTableTest do
       ]
 
       actual =
-        Enum.sort_by(
-          Enum.filter(CubicTable.all_with_ods_table_snapshot(), fn {table, _ods_table_snapshot} ->
-            Enum.member?([dmap_table_id, ods_table_id], table.id)
-          end),
-          fn {table, _ods_table_snapshot} -> table.id end
-        )
+        Enum.filter(CubicTable.all_with_ods_table_snapshot(), fn {table, _ods_table_snapshot} ->
+          Enum.member?([dmap_table_id, ods_table_id], table.id)
+        end)
 
       assert expected == actual
     end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/start_ingestion_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/start_ingestion_test.exs
@@ -3,6 +3,7 @@ defmodule ExCubicIngestion.StartIngestionTest do
   use Oban.Testing, repo: ExCubicIngestion.Repo
 
   alias ExCubicIngestion.Schema.CubicLoad
+  alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
   alias ExCubicIngestion.Schema.CubicTable
   alias ExCubicIngestion.StartIngestion
   alias ExCubicIngestion.Workers.Ingest
@@ -26,6 +27,23 @@ defmodule ExCubicIngestion.StartIngestionTest do
           s3_prefix: "cubic/dmap/sample/"
         })
 
+      ods_table =
+        Repo.insert!(%CubicTable{
+          name: "cubic_ods_qlik__sample",
+          s3_prefix: "cubic/ods_qlik/SAMPLE/"
+        })
+
+      # insert ODS table
+      ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv.gz"
+      ods_snapshot = ~U[2022-01-02 20:49:50Z]
+
+      Repo.insert!(%CubicOdsTableSnapshot{
+        table_id: ods_table.id,
+        snapshot: nil,
+        snapshot_s3_key: ods_snapshot_s3_key
+      })
+
+      # insert loads
       dmap_load =
         Repo.insert!(%CubicLoad{
           table_id: dmap_table.id,
@@ -37,11 +55,29 @@ defmodule ExCubicIngestion.StartIngestionTest do
 
       dmap_load_id = dmap_load.id
 
+      ods_load =
+        Repo.insert!(%CubicLoad{
+          table_id: ods_table.id,
+          status: "ready",
+          s3_key: ods_snapshot_s3_key,
+          s3_modified: ods_snapshot,
+          s3_size: 197
+        })
+
+      ods_load_id = ods_load.id
+
       :ok = StartIngestion.run()
 
+      # snapshot was updated
+      assert CubicOdsTableSnapshot.get_by!(%{table_id: ods_table.id}).snapshot == ods_snapshot
+
+      # status was updated
       assert CubicLoad.get!(dmap_load_id).status == "ingesting"
 
-      assert_enqueued(worker: Ingest, args: %{load_rec_ids: [dmap_load_id]})
+      assert CubicLoad.get!(ods_load_id).status == "ingesting"
+
+      # job have been queued
+      assert_enqueued(worker: Ingest, args: %{load_rec_ids: [dmap_load_id, ods_load_id]})
     end
   end
 

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/start_ingestion_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/start_ingestion_test.exs
@@ -3,64 +3,12 @@ defmodule ExCubicIngestion.StartIngestionTest do
   use Oban.Testing, repo: ExCubicIngestion.Repo
 
   alias ExCubicIngestion.Schema.CubicLoad
-  alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
   alias ExCubicIngestion.Schema.CubicTable
   alias ExCubicIngestion.StartIngestion
   alias ExCubicIngestion.Workers.Ingest
 
   require MockExAws.Data
   require Logger
-
-  setup do
-    # insert tables
-    dmap_table =
-      Repo.insert!(%CubicTable{
-        name: "cubic_dmap__sample",
-        s3_prefix: "cubic/dmap/sample/"
-      })
-
-    ods_table =
-      Repo.insert!(%CubicTable{
-        name: "cubic_ods_qlik__sample",
-        s3_prefix: "cubic/ods_qlik/SAMPLE/"
-      })
-
-    # insert ODS table
-    ods_snapshot_s3_key = "cubic/ods_qlik/SAMPLE/LOAD1.csv.gz"
-
-    Repo.insert!(%CubicOdsTableSnapshot{
-      table_id: ods_table.id,
-      snapshot: nil,
-      snapshot_s3_key: ods_snapshot_s3_key
-    })
-
-    # insert loads
-    dmap_load =
-      Repo.insert!(%CubicLoad{
-        table_id: dmap_table.id,
-        status: "ready",
-        s3_key: "cubic/dmap/sample/20220101.csv.gz",
-        s3_modified: ~U[2022-01-01 20:49:50Z],
-        s3_size: 197
-      })
-
-    ods_load =
-      Repo.insert!(%CubicLoad{
-        table_id: ods_table.id,
-        status: "ready",
-        s3_key: ods_snapshot_s3_key,
-        s3_modified: ~U[2022-01-01 20:49:50Z],
-        s3_size: 197
-      })
-
-    {:ok,
-     %{
-       load_rec_ids: [
-         dmap_load.id,
-         ods_load.id
-       ]
-     }}
-  end
 
   describe "status/0" do
     test "running state" do
@@ -71,17 +19,29 @@ defmodule ExCubicIngestion.StartIngestionTest do
   end
 
   describe "run/0" do
-    test "schedules ingestion jobs for ready loads", %{
-      load_rec_ids: load_rec_ids
-    } do
+    test "schedules ingestion jobs for ready loads" do
+      dmap_table =
+        Repo.insert!(%CubicTable{
+          name: "cubic_dmap__sample",
+          s3_prefix: "cubic/dmap/sample/"
+        })
+
+      dmap_load =
+        Repo.insert!(%CubicLoad{
+          table_id: dmap_table.id,
+          status: "ready",
+          s3_key: "cubic/dmap/sample/20220101.csv.gz",
+          s3_modified: ~U[2022-01-01 20:49:50Z],
+          s3_size: 197
+        })
+
+      dmap_load_id = dmap_load.id
+
       :ok = StartIngestion.run()
 
-      for load_rec_id <- load_rec_ids,
-          load_rec = CubicLoad.get!(load_rec_id) do
-        assert load_rec.status == "ingesting"
-      end
+      assert CubicLoad.get!(dmap_load_id).status == "ingesting"
 
-      assert_enqueued(worker: Ingest, args: %{load_rec_ids: load_rec_ids})
+      assert_enqueued(worker: Ingest, args: %{load_rec_ids: [dmap_load_id]})
     end
   end
 


### PR DESCRIPTION
This PR continues the work on optimizing the processes and creating a stable ECS container environment from this [Asana task](https://app.asana.com/0/1201701089427502/1202462260207371). We introduce a different way for querying for 'ready' loads by first getting all the active tables and then querying the 'ready' loads for each table (with a limit). For ODS, we also utilize the last snapshot load, so we only get the loads that we know exist and have not been remove by Qlik during a restart.  An [Asana ticket](https://app.asana.com/0/1201701089427502/1202900902122498) has been created to think through what we do with these 'ready' load records that are now pointing to non-existent objects.

Previously, if there were a lot of 'ready' loads, the process might take a really long time to get to the adding of the ingestion jobs.