### PR TITLE
[db] feat: add new dmap agg_daily_fareprod table for consumption

### DIFF
--- a/ex_cubic_ingestion/priv/repo/migrations/20220831024427_add_agg_daily_fareprod_dmap_table.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20220831024427_add_agg_daily_fareprod_dmap_table.exs
@@ -1,0 +1,20 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddAggDailyFareprodDmapTable do
+  use Ecto.Migration
+
+  alias ExCubicIngestion.Repo
+  alias ExCubicIngestion.Schema.CubicTable
+
+  def up do
+    Repo.insert!(%CubicTable{
+      name: "cubic_dmap__agg_daily_fareprod",
+      s3_prefix: "cubic/dmap/agg_daily_fareprod/",
+      is_raw: true
+    })
+  end
+
+  def down do
+    Repo.delete!(CubicTable.get_by!(
+      name: "cubic_dmap__agg_daily_fareprod"
+    ))
+  end
+end


### PR DESCRIPTION
This PR adds the DMAP's `agg_daily_fareprod` table for consumption. This table was made available by Cubic in the latest revision, linked to in this Asana ticket: https://app.asana.com/0/1201290014466247/1202348192935957
