### PR TITLE
[elixir] feat: insert new objects only if new since last inserted load

### DIFF
--- a/ex_cubic_ingestion/priv/repo/migrations/20220831174254_add_index_for_load_table_id.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20220831174254_add_index_for_load_table_id.exs
@@ -1,0 +1,11 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddIndexForLoadTableId do
+  use Ecto.Migration
+
+  def up do
+    create index("cubic_loads", [:table_id, :deleted_at])
+  end
+
+  def down do
+    drop index("cubic_loads", [:table_id, :deleted_at])
+  end
+end


### PR DESCRIPTION
This PR continues optimization work for creating a stable ECS container (see [Asana task](https://app.asana.com/0/1201701089427502/1202462260207371)). We introduce a new way of figuring out what is new from the list of S3 objects. We query for the last inserted load record for each table, and only insert S3 objects that are new since the last inserted load, using on the `s3_modified`.
