### PR TITLE
[elixir] limit query for ready_for_archiving/erroring loads

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_ingestion.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/process_ingestion.ex
@@ -53,7 +53,9 @@ defmodule ExCubicIngestion.ProcessIngestion do
   @spec run(map()) :: map()
   defp run(state) do
     # get list of load records that are ready for archive/error, and process them
-    process_loads(CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"]))
+    ["ready_for_archiving", "ready_for_erroring"]
+    |> CubicLoad.all_by_status_in()
+    |> process_loads()
 
     # return
     state

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
@@ -183,11 +183,12 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
   @doc """
   Get records by a list of statuses.
   """
-  @spec all_by_status_in([String.t()]) :: [t()]
-  def all_by_status_in(statuses) do
+  @spec all_by_status_in([String.t()], integer()) :: [t()]
+  def all_by_status_in(statuses, limit \\ 1000) do
     query =
       from(load in not_deleted(),
-        where: load.status in ^statuses
+        where: load.status in ^statuses,
+        limit: ^limit
       )
 
     Repo.all(query)

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_load.ex
@@ -188,6 +188,7 @@ defmodule ExCubicIngestion.Schema.CubicLoad do
     query =
       from(load in not_deleted(),
         where: load.status in ^statuses,
+        order_by: load.id,
         limit: ^limit
       )
 

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
@@ -184,7 +184,7 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
     end
   end
 
-  describe "all_by_status_in/1" do
+  describe "all_by_status_in/2" do
     test "empty list of statuses" do
       assert [] == CubicLoad.all_by_status_in([])
     end
@@ -211,10 +211,8 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
           s3_size: 197
         })
 
-      actual_loads = CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"])
-
-      assert [load_1.id, load_2.id] ==
-               Enum.sort(Enum.map(actual_loads, & &1.id))
+      assert [load_1, load_2] ==
+               CubicLoad.all_by_status_in(["ready_for_archiving", "ready_for_erroring"])
     end
 
     test "limiting the number of records returned", %{

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_load_test.exs
@@ -216,6 +216,29 @@ defmodule ExCubicIngestion.Schema.CubicLoadTest do
       assert [load_1.id, load_2.id] ==
                Enum.sort(Enum.map(actual_loads, & &1.id))
     end
+
+    test "limiting the number of records returned", %{
+      table: table
+    } do
+      # insert loads
+      Repo.insert!(%CubicLoad{
+        table_id: table.id,
+        status: "ready_for_archiving",
+        s3_key: "cubic/dmap/sample/20220101.csv.gz",
+        s3_modified: ~U[2022-01-01 20:49:50Z],
+        s3_size: 197
+      })
+
+      Repo.insert!(%CubicLoad{
+        table_id: table.id,
+        status: "ready_for_archiving",
+        s3_key: "cubic/dmap/sample/20220102.csv.gz",
+        s3_modified: ~U[2022-01-02 20:49:50Z],
+        s3_size: 197
+      })
+
+      assert 1 == length(CubicLoad.all_by_status_in(["ready_for_archiving"], 1))
+    end
   end
 
   describe "update/2" do


### PR DESCRIPTION
This PR continues the optimizations for running a more stable ECS container, see [Asana task](https://app.asana.com/0/1201290014466247/1202462260207371). For this update, we make a small optimization to limit the query so in the case that there are a lot of loads to be archived/errored, the process doesn't take too long to run.