### PR TITLE
[db] feat: add agg_daily_fareprod dmap feed

### DIFF
--- a/ex_cubic_ingestion/priv/repo/migrations/20220919141025_add_agg_daily_fareprod_dmap_feed.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20220919141025_add_agg_daily_fareprod_dmap_feed.exs
@@ -1,0 +1,19 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddAggDailyFareprodDmapFeed do
+  use Ecto.Migration
+
+  alias ExCubicIngestion.Repo
+  alias ExCubicIngestion.Schema.CubicDmapFeed
+
+  def up do
+    Repo.insert!(%CubicDmapFeed{
+      relative_url: "/controlledresearchusersapi/aggregations/agg_daily_fareprod",
+      last_updated_at: ~U[2022-09-01 00:00:00.000000Z]
+    })
+  end
+
+  def down do
+    Repo.delete!(CubicDmapFeed.get_by!(
+      relative_url: "/controlledresearchusersapi/aggregations/agg_daily_fareprod"
+    ))
+  end
+end


### PR DESCRIPTION
This PR allows the agg_daily_fareprod to be fetched. It wasn't previously, although it was setup for ingestion with [this PR](https://github.com/mbta/data_platform/pull/76). 
An [Asana task](https://app.asana.com/0/1201701089427502/1203005077372126) has been added to update the docs, so we don't miss this detail in the future.