### PR TITLE
[elixir] feat: add info for args when worker has exception

### DIFF
--- a/ex_cubic_ingestion/config/test.exs
+++ b/ex_cubic_ingestion/config/test.exs
@@ -1,7 +1,7 @@
 import Config
 
 # only log warnings+ in test
-config :logger, level: :warning
+config :logger, level: :info
 
 config :ex_cubic_ingestion,
   start_app_children?: false

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/oban_logger.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/oban_logger.ex
@@ -3,6 +3,9 @@ defmodule ExCubicIngestion.ObanLogger do
   This module allows for logging more specific messages from Oban's telemetry.
   """
 
+  alias ExCubicIngestion.Schema.CubicDmapFeed
+  alias ExCubicIngestion.Schema.CubicLoad
+
   require Logger
 
   @log_prefix "[ex_cubic_ingestion] [workers]"
@@ -25,9 +28,53 @@ defmodule ExCubicIngestion.ObanLogger do
     )
   end
 
+  def handle_event(
+        [:oban, :job, :exception],
+        measure,
+        %{worker: worker} = meta,
+        _config
+      )
+      when worker in ["ExCubicIngestion.Workers.Archive", "ExCubicIngestion.Workers.Error"] do
+    %{"load_rec_id" => load_rec_id} = meta.args
+
+    args_info = CubicLoad.get!(load_rec_id)
+
+    log_exception(measure, meta, args_info)
+  end
+
+  def handle_event(
+        [:oban, :job, :exception],
+        measure,
+        %{worker: "ExCubicIngestion.Workers.FetchDmap"} = meta,
+        _config
+      ) do
+    %{"feed_id" => feed_id} = meta.args
+
+    args_info = CubicDmapFeed.get!(feed_id)
+
+    log_exception(measure, meta, args_info)
+  end
+
+  def handle_event(
+        [:oban, :job, :exception],
+        measure,
+        %{worker: "ExCubicIngestion.Workers.Ingest"} = meta,
+        _config
+      ) do
+    %{"load_rec_ids" => load_rec_ids} = meta.args
+
+    args_info = CubicLoad.get_many_with_table(load_rec_ids)
+
+    log_exception(measure, meta, args_info)
+  end
+
   def handle_event([:oban, :job, :exception], measure, meta, _config) do
+    log_exception(measure, meta, {})
+  end
+
+  defp log_exception(measure, meta, args_info) do
     Logger.error(
-      "#{@log_prefix} [#{meta.queue}] Exception: args=#{inspect(meta.args, charlists: :as_lists)} duration=#{measure.duration} queue_time=#{measure.queue_time} state=#{meta.state} attempt=#{meta.attempt} kind=#{meta.kind} error=#{inspect(meta.error)}\nStacktrace:\n#{Exception.format_stacktrace(meta.stacktrace)}"
+      "#{@log_prefix} [#{meta.queue}] Exception: args=#{inspect(meta.args, charlists: :as_lists)} duration=#{measure.duration} queue_time=#{measure.queue_time} state=#{meta.state} attempt=#{meta.attempt} kind=#{meta.kind} error=#{inspect(meta.error)}\nargs_info: #{inspect(args_info)}\nStacktrace:\n#{Exception.format_stacktrace(meta.stacktrace)}"
     )
   end
 end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/oban_logger_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/oban_logger_test.exs
@@ -1,0 +1,155 @@
+defmodule ExCubicIngestion.Schema.ObanLoggerTest do
+  @moduledoc """
+  Test for ingest worker error handler.
+  """
+
+  use ExCubicIngestion.DataCase
+
+  import ExCubicIngestion.TestFixtures, only: [setup_tables_loads: 1]
+  import ExUnit.CaptureLog
+
+  alias ExCubicIngestion.ObanLogger
+  alias ExCubicIngestion.Schema.CubicDmapFeed
+
+  setup :setup_tables_loads
+
+  describe "handle_event/4" do
+    test "worker start log info" do
+      assert capture_log(fn ->
+               ObanLogger.handle_event(
+                 [:oban, :job, :start],
+                 %{},
+                 %{queue: "archive", args: []},
+                 %{}
+               )
+             end) =~ "[archive] Start"
+    end
+
+    test "worker stop, logs info" do
+      assert capture_log(fn ->
+               ObanLogger.handle_event(
+                 [:oban, :job, :stop],
+                 %{duration: 1, queue_time: 1},
+                 %{queue: "archive", args: [], state: "", attempt: 1},
+                 %{}
+               )
+             end) =~ "[archive] Stop"
+    end
+
+    test "archive worker exception, logs error", %{
+      dmap_load: dmap_load
+    } do
+      assert capture_log(fn ->
+               ObanLogger.handle_event(
+                 [:oban, :job, :exception],
+                 %{duration: 1, queue_time: 1},
+                 %{
+                   worker: "ExCubicIngestion.Workers.Archive",
+                   queue: "archive",
+                   args: %{"load_rec_id" => dmap_load.id},
+                   state: "",
+                   attempt: 1,
+                   kind: "",
+                   error: "",
+                   stacktrace: nil
+                 },
+                 %{}
+               )
+             end) =~ dmap_load.s3_key
+    end
+
+    test "error worker exception, logs error", %{
+      dmap_load: dmap_load
+    } do
+      assert capture_log(fn ->
+               ObanLogger.handle_event(
+                 [:oban, :job, :exception],
+                 %{duration: 1, queue_time: 1},
+                 %{
+                   worker: "ExCubicIngestion.Workers.Error",
+                   queue: "error",
+                   args: %{"load_rec_id" => dmap_load.id},
+                   state: "",
+                   attempt: 1,
+                   kind: "",
+                   error: "",
+                   stacktrace: nil
+                 },
+                 %{}
+               )
+             end) =~ dmap_load.s3_key
+    end
+
+    test "fetch dmap worker exception, logs error" do
+      dmap_feed =
+        Repo.insert!(%CubicDmapFeed{
+          relative_url: "/controlledresearchusersapi/sample"
+        })
+
+      assert capture_log(fn ->
+               ObanLogger.handle_event(
+                 [:oban, :job, :exception],
+                 %{duration: 1, queue_time: 1},
+                 %{
+                   worker: "ExCubicIngestion.Workers.FetchDmap",
+                   queue: "fetch_dmap",
+                   args: %{"feed_id" => dmap_feed.id},
+                   state: "",
+                   attempt: 1,
+                   kind: "",
+                   error: "",
+                   stacktrace: nil
+                 },
+                 %{}
+               )
+             end) =~ dmap_feed.relative_url
+    end
+
+    test "ingest worker exception, logs error", %{
+      dmap_load: dmap_load,
+      ods_load: ods_load
+    } do
+      log =
+        capture_log(fn ->
+          ObanLogger.handle_event(
+            [:oban, :job, :exception],
+            %{duration: 1, queue_time: 1},
+            %{
+              worker: "ExCubicIngestion.Workers.Ingest",
+              queue: "ingest",
+              args: %{"load_rec_ids" => [ods_load.id, dmap_load.id]},
+              state: "",
+              attempt: 1,
+              kind: "",
+              error: "",
+              stacktrace: nil
+            },
+            %{}
+          )
+        end)
+
+      assert log =~ dmap_load.s3_key
+      assert log =~ ods_load.s3_key
+    end
+
+    test "catch all worker exception, logs error" do
+      assert capture_log(fn ->
+               ObanLogger.handle_event(
+                 [:oban, :job, :exception],
+                 %{duration: 1, queue_time: 1},
+                 %{
+                   worker: "ExCubicIngestion.Workers.Any",
+                   queue: "any",
+                   args: %{},
+                   state: "",
+                   attempt: 1,
+                   kind: "",
+                   error: "",
+                   stacktrace: nil
+                 },
+                 %{}
+               )
+             end) =~ "[any] Exception"
+    end
+  end
+end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/oban_logger_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/oban_logger_test.exs
@@ -44,7 +44,6 @@ defmodule ExCubicIngestion.Schema.ObanLoggerTest do
                  [:oban, :job, :exception],
                  %{duration: 1, queue_time: 1},
                  %{
-                   worker: "ExCubicIngestion.Workers.Archive",
                    queue: "archive",
                    args: %{"load_rec_id" => dmap_load.id},
                    state: "",
@@ -66,7 +65,6 @@ defmodule ExCubicIngestion.Schema.ObanLoggerTest do
                  [:oban, :job, :exception],
                  %{duration: 1, queue_time: 1},
                  %{
-                   worker: "ExCubicIngestion.Workers.Error",
                    queue: "error",
                    args: %{"load_rec_id" => dmap_load.id},
                    state: "",
@@ -91,7 +89,6 @@ defmodule ExCubicIngestion.Schema.ObanLoggerTest do
                  [:oban, :job, :exception],
                  %{duration: 1, queue_time: 1},
                  %{
-                   worker: "ExCubicIngestion.Workers.FetchDmap",
                    queue: "fetch_dmap",
                    args: %{"feed_id" => dmap_feed.id},
                    state: "",
@@ -115,7 +112,6 @@ defmodule ExCubicIngestion.Schema.ObanLoggerTest do
             [:oban, :job, :exception],
             %{duration: 1, queue_time: 1},
             %{
-              worker: "ExCubicIngestion.Workers.Ingest",
               queue: "ingest",
               args: %{"load_rec_ids" => [ods_load.id, dmap_load.id]},
               state: "",
@@ -138,7 +134,6 @@ defmodule ExCubicIngestion.Schema.ObanLoggerTest do
                  [:oban, :job, :exception],
                  %{duration: 1, queue_time: 1},
                  %{
-                   worker: "ExCubicIngestion.Workers.Any",
                    queue: "any",
                    args: %{},
                    state: "",

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/oban_worker_error_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/oban_worker_error_test.exs
@@ -1,6 +1,6 @@
 defmodule ExCubicIngestion.Schema.ObanWorkerErrorTest do
   @moduledoc """
-  Test for ingest worker error handler.
+  Test for worker error handler.
   """
 
   use ExCubicIngestion.DataCase, async: true


### PR DESCRIPTION
This PR adds more logging to help in narrowing down exceptions. We usually get this information when a Glue job starts and is running, but if the exception occurs before, we wouldn't have the information. We also add testing for the logs.