### PR TITLE
[elixir] feat: oban will wait for jobs to finish before shutting down

### DIFF
--- a/ex_cubic_ingestion/config/config.exs
+++ b/ex_cubic_ingestion/config/config.exs
@@ -12,6 +12,8 @@ config :ex_cubic_ingestion,
 
 config :ex_cubic_ingestion, Oban,
   repo: ExCubicIngestion.Repo,
+  # 15 minutes
+  shutdown_grace_period: 900_000,
   plugins: [
     {
       Oban.Plugins.Cron,


### PR DESCRIPTION
With this PR, we have configured Oban to wait until jobs have finished before allowing the shut down of the application, and hence the container.