### PR TITLE
[elixir] hotfix: get only one record for the ods load snapshot

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_ods_load_snapshot.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/schema/cubic_ods_load_snapshot.ex
@@ -49,6 +49,17 @@ defmodule ExCubicIngestion.Schema.CubicOdsLoadSnapshot do
     Repo.get_by!(not_deleted(), clauses, opts)
   end
 
+  @spec get_latest_by!(Keyword.t() | map()) :: t() | nil
+  def get_latest_by!(clauses) do
+    Repo.one!(
+      from(ods_load_snapshot in not_deleted(),
+        where: ^clauses,
+        order_by: [desc: ods_load_snapshot.inserted_at],
+        limit: 1
+      )
+    )
+  end
+
   @doc """
   Updates snapshots for ODS table (if needed), and inserts new ODS load snapshot.
   """

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/archive.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/archive.ex
@@ -84,11 +84,11 @@ defmodule ExCubicIngestion.Workers.Archive do
   def construct_destination_key_root(load_rec) do
     # for ODS, the destination will include the snapshot to prevent from overwriting
     if CubicLoad.ods_load?(load_rec.s3_key) do
-      ods_load_rec = CubicOdsLoadSnapshot.get_by!(load_id: load_rec.id)
+      ods_load_snapshot_rec = CubicOdsLoadSnapshot.get_latest_by!(load_id: load_rec.id)
 
       Enum.join([
         Path.dirname(load_rec.s3_key),
-        '/snapshot=#{Calendar.strftime(ods_load_rec.snapshot, "%Y%m%dT%H%M%SZ")}/',
+        '/snapshot=#{Calendar.strftime(ods_load_snapshot_rec.snapshot, "%Y%m%dT%H%M%SZ")}/',
         Path.basename(load_rec.s3_key, ".csv.gz")
       ])
     else

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/ingest.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/ingest.ex
@@ -159,7 +159,7 @@ defmodule ExCubicIngestion.Workers.Ingest do
   @spec attach_ods_snapshot(map()) :: map()
   defp attach_ods_snapshot(%{partition_columns: partition_columns} = load) do
     if CubicLoad.ods_load?(load[:s3_key]) do
-      ods_load_snapshot_rec = CubicOdsLoadSnapshot.get_by!(load_id: load[:id])
+      ods_load_snapshot_rec = CubicOdsLoadSnapshot.get_latest_by!(load_id: load[:id])
 
       # note: order of partitions is intentional
       %{


### PR DESCRIPTION
This PR addresses an issue where while running an 'ingest' job, the app is pulling the snapshot record for the load, and it is receiving back thousands of records. It should really just receive one record back, but due to an issue in the start_ingestion process, these records kept inserting since the load was not being moved out of the 'ready' status.
There is some additional work to make sure this works correctly. They will be addressed as part of [this bug](https://app.asana.com/0/1201701089427502/1202701470464832). More specifically:
1. Need to change 'start_ingestion' to just run through and update ODS table snapshot, insert load snapshot, check schema, and update status of load to 'ready_for_ingesting', all within a transaction.
2. Update 'process_ingestion' to also start 'ingest' jobs, based on 'ready_for_ingesting' status.