### PR TITLE
[elixir] fix: ehmon config in the correct place

### DIFF
--- a/ex_cubic_ingestion/config/config.exs
+++ b/ex_cubic_ingestion/config/config.exs
@@ -28,8 +28,6 @@ config :ex_cubic_ingestion, Oban,
     schedule_dmap: 1
   ]
 
-config :ehmon, :report_mf, {:ehmon, :info_report}
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/ex_cubic_ingestion/config/prod.exs
+++ b/ex_cubic_ingestion/config/prod.exs
@@ -12,3 +12,5 @@ config :ex_aws,
   # overwrite defaults here, so as to only look at instance role
   access_key_id: :instance_role,
   secret_access_key: :instance_role
+
+config :ehmon, :report_mf, {:ehmon, :info_report}


### PR DESCRIPTION
This PR addresses a warning on local for not having 'ehmon' as a dependency when running the application. Moving it to the prod configuration avoids this warning and is the correct place to put this.