### PR TITLE
[data] fix: add PK info for dfm sample data

### DIFF
--- a/sample_data/cubic/ods_qlik/EDW.SAMPLE/LOAD1.dfm
+++ b/sample_data/cubic/ods_qlik/EDW.SAMPLE/LOAD1.dfm
@@ -44,7 +44,7 @@
                 "length": 10,
                 "precision": 0,
                 "scale": 0,
-                "primaryKeyPos": 0
+                "primaryKeyPos": 1
             },
             {
                 "ordinal": 2,

--- a/sample_data/cubic/ods_qlik/EDW.SAMPLE/LOAD2.dfm
+++ b/sample_data/cubic/ods_qlik/EDW.SAMPLE/LOAD2.dfm
@@ -44,7 +44,7 @@
                 "length": 10,
                 "precision": 0,
                 "scale": 0,
-                "primaryKeyPos": 0
+                "primaryKeyPos": 1
             },
             {
                 "ordinal": 2,

--- a/sample_data/cubic/ods_qlik/EDW.SAMPLE__ct/20211201-112233444.dfm
+++ b/sample_data/cubic/ods_qlik/EDW.SAMPLE__ct/20211201-112233444.dfm
@@ -1,97 +1,105 @@
 {
-    "dfmVersion":   "1.1",
+    "dfmVersion": "1.1",
     "taskInfo": {
         "name": "",
-        "sourceEndpoint":   "",
-        "sourceEndpointType":   "",
-        "sourceEndpointUser":   "",
-        "replicationServer":    "",
-        "operation":    ""
+        "sourceEndpoint": "",
+        "sourceEndpointType": "",
+        "sourceEndpointUser": "",
+        "replicationServer": "",
+        "operation": ""
     },
     "fileInfo": {
         "name": "20211201-112233444.csv",
-        "extension":    "gz",
+        "extension": "gz",
         "location": "incoming/cubic/ods_qlik/EDW.SAMPLE__ct",
-        "startWriteTimestamp":  "",
-        "endWriteTimestamp":    "",
-        "firstTransactionTimestamp":    null,
+        "startWriteTimestamp": "",
+        "endWriteTimestamp": "",
+        "firstTransactionTimestamp": null,
         "lastTransactionTimestamp": null,
-        "content":  "data",
-        "recordCount":  2,
-        "errorCount":   0
+        "content": "data",
+        "recordCount": 2,
+        "errorCount": 0
     },
-    "formatInfo":   {
-        "format":   "delimited",
-        "options":  {
-            "fieldDelimiter":   ",",
-            "recordDelimiter":  "\n",
-            "nullValue":    "",
-            "quoteChar":    "\"",
-            "escapeChar":   ""
+    "formatInfo": {
+        "format": "delimited",
+        "options": {
+            "fieldDelimiter": ",",
+            "recordDelimiter": "\n",
+            "nullValue": "",
+            "quoteChar": "\"",
+            "escapeChar": ""
         }
     },
     "dataInfo": {
         "sourceSchema": "EDW",
-        "sourceTable":  "SAMPLE",
+        "sourceTable": "SAMPLE",
         "targetSchema": "EDW",
-        "targetTable":  "SAMPLE__ct",
+        "targetTable": "SAMPLE__ct",
         "tableVersion": 1,
-        "columns":  [{
-                "ordinal":  1,
+        "columns": [
+            {
+                "ordinal": 1,
                 "name": "header__change_seq",
                 "type": "STRING",
-                "length":   35,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  2,
+                "length": 35,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 2,
                 "name": "header__change_oper",
                 "type": "STRING",
-                "length":   1,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  3,
+                "length": 1,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 3,
                 "name": "header__timestamp",
                 "type": "DATETIME",
-                "length":   0,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  4,
+                "length": 0,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 4,
                 "name": "SAMPLE_ID",
                 "type": "INT4",
-                "length":   10,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  5,
+                "length": 10,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 1
+            },
+            {
+                "ordinal": 5,
                 "name": "SAMPLE_NAME",
                 "type": "STRING",
-                "length":   100,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  6,
+                "length": 100,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 6,
                 "name": "EDW_INSERTED_DTM",
                 "type": "DATETIME",
-                "length":   0,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  7,
+                "length": 0,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 7,
                 "name": "EDW_UPDATED_DTM",
                 "type": "DATETIME",
-                "length":   0,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }]
+                "length": 0,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            }
+        ]
     }
 }

--- a/sample_data/cubic/ods_qlik/EDW.SAMPLE__ct/20211201-122433444.dfm
+++ b/sample_data/cubic/ods_qlik/EDW.SAMPLE__ct/20211201-122433444.dfm
@@ -1,97 +1,105 @@
 {
-    "dfmVersion":   "1.1",
+    "dfmVersion": "1.1",
     "taskInfo": {
         "name": "",
-        "sourceEndpoint":   "",
-        "sourceEndpointType":   "",
-        "sourceEndpointUser":   "",
-        "replicationServer":    "",
-        "operation":    ""
+        "sourceEndpoint": "",
+        "sourceEndpointType": "",
+        "sourceEndpointUser": "",
+        "replicationServer": "",
+        "operation": ""
     },
     "fileInfo": {
         "name": "20211201-112233444.csv",
-        "extension":    "gz",
+        "extension": "gz",
         "location": "incoming/cubic/ods_qlik/EDW.SAMPLE__ct",
-        "startWriteTimestamp":  "",
-        "endWriteTimestamp":    "",
-        "firstTransactionTimestamp":    null,
+        "startWriteTimestamp": "",
+        "endWriteTimestamp": "",
+        "firstTransactionTimestamp": null,
         "lastTransactionTimestamp": null,
-        "content":  "data",
-        "recordCount":  2,
-        "errorCount":   0
+        "content": "data",
+        "recordCount": 2,
+        "errorCount": 0
     },
-    "formatInfo":   {
-        "format":   "delimited",
-        "options":  {
-            "fieldDelimiter":   ",",
-            "recordDelimiter":  "\n",
-            "nullValue":    "",
-            "quoteChar":    "\"",
-            "escapeChar":   ""
+    "formatInfo": {
+        "format": "delimited",
+        "options": {
+            "fieldDelimiter": ",",
+            "recordDelimiter": "\n",
+            "nullValue": "",
+            "quoteChar": "\"",
+            "escapeChar": ""
         }
     },
     "dataInfo": {
         "sourceSchema": "EDW",
-        "sourceTable":  "SAMPLE",
+        "sourceTable": "SAMPLE",
         "targetSchema": "EDW",
-        "targetTable":  "SAMPLE__ct",
+        "targetTable": "SAMPLE__ct",
         "tableVersion": 1,
-        "columns":  [{
-                "ordinal":  1,
+        "columns": [
+            {
+                "ordinal": 1,
                 "name": "header__change_seq",
                 "type": "STRING",
-                "length":   35,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  2,
+                "length": 35,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 2,
                 "name": "header__change_oper",
                 "type": "STRING",
-                "length":   1,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  3,
+                "length": 1,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 3,
                 "name": "header__timestamp",
                 "type": "DATETIME",
-                "length":   0,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  4,
+                "length": 0,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 4,
                 "name": "SAMPLE_ID",
                 "type": "INT4",
-                "length":   10,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  5,
+                "length": 10,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 1
+            },
+            {
+                "ordinal": 5,
                 "name": "SAMPLE_NAME",
                 "type": "STRING",
-                "length":   100,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  6,
+                "length": 100,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 6,
                 "name": "EDW_INSERTED_DTM",
                 "type": "DATETIME",
-                "length":   0,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }, {
-                "ordinal":  7,
+                "length": 0,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            },
+            {
+                "ordinal": 7,
                 "name": "EDW_UPDATED_DTM",
                 "type": "DATETIME",
-                "length":   0,
-                "precision":    0,
-                "scale":    0,
-                "primaryKeyPos":    0
-            }]
+                "length": 0,
+                "precision": 0,
+                "scale": 0,
+                "primaryKeyPos": 0
+            }
+        ]
     }
 }


### PR DESCRIPTION
Solved the mystery for how we can update rows. Qlik sends over a primary key designation for tables through their `.dfm` files. We will eventually use this to make targeted updates to rows at a final destination beyond the data lake. In this PR, we wanted to update the sample data to show this designation.