### PR TITLE
[elixir] fix: ingestion process crashes when missing schema file

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/validate_incoming.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/validate_incoming.ex
@@ -71,7 +71,7 @@ defmodule ExCubicIngestion.ValidateIncoming do
     # log and error out invalid ones
     Enum.each(invalid_ready_loads, fn {load_rec, _table_rec} = ready_load ->
       Logger.error(
-        "[ex_cubic_ingestion] [start_ingestion] Invalid schema detected: #{inspect(ready_load)}"
+        "[ex_cubic_ingestion] [validate_incoming] Invalid schema detected: #{inspect(ready_load)}"
       )
 
       CubicLoad.update(load_rec, %{status: "ready_for_erroring"})
@@ -84,7 +84,9 @@ defmodule ExCubicIngestion.ValidateIncoming do
   defp valid_schema?(state, {load_rec, table_rec}) do
     # if ODS, check the schema provided by Cubic (.dfm files) against Glue
     if CubicLoad.ods_load?(load_rec.s3_key) do
-      SchemaFetch.get_cubic_ods_qlik_columns(state.lib_ex_aws, load_rec) ==
+      qlik_columns = SchemaFetch.get_cubic_ods_qlik_columns(state.lib_ex_aws, load_rec)
+
+      qlik_columns ==
         SchemaFetch.get_glue_columns(state.lib_ex_aws, table_rec, load_rec)
     else
       # @todo implement DMAP schema checker once we have the schema API from Cubic

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/validate_incoming_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/validate_incoming_test.exs
@@ -71,7 +71,7 @@ defmodule ExCubicIngestion.ValidateIncomingTest do
       assert CubicLoad.get!(ods_load.id).status == "ready_for_ingesting"
 
       # for invalid, logged and status was updated to error out
-      assert process_logs =~ "[start_ingestion] Invalid schema detected"
+      assert process_logs =~ "[validate_incoming] Invalid schema detected"
 
       assert CubicLoad.get!(invalid_ods_load.id).status == "ready_for_erroring"
     end

--- a/ex_cubic_ingestion/test/support/ex_aws.ex
+++ b/ex_cubic_ingestion/test/support/ex_aws.ex
@@ -145,6 +145,16 @@ defmodule MockExAws do
            """
          }}
 
+      path == "#{incoming_prefix}cubic/ods_qlik/SAMPLE/notfound_LOAD3.dfm" ->
+        {:error,
+         {:http_error, 404,
+          %{
+            body:
+              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>cubic/ods_qlik/SAMPLE/notfound_LOAD3.dfm</Key><RequestId>...</RequestId><HostId>...</HostId></Error>",
+            headers: [],
+            status_code: 404
+          }}}
+
       true ->
         {:error, "get_object failed"}
     end


### PR DESCRIPTION
This PR addresses an issue where a missing schema file for a data file was causing the validate_incoming process to crash. We now log this issue and allow the process to move to the load to a 'ready_for_erroring' status.