### PR TITLE
[elixir] feat: add language table for ingestion

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,6 @@ adr-tools 3.0.0
 elixir 1.13.2-otp-24
 erlang 24.2.1
 java openjdk-11
-poetry 1.1.13
+poetry 1.4.2
 python 3.7.12
 terraform 1.1.8

--- a/ex_cubic_ingestion/priv/repo/migrations/20230508154111_add_language_table.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20230508154111_add_language_table.exs
@@ -1,0 +1,28 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddLanguageTable do
+  use Ecto.Migration
+
+  alias ExCubicIngestion.Repo
+  alias ExCubicIngestion.Schema.CubicTable
+  alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
+
+  @ods_table_name "cubic_ods_qlik__edw_language"
+  @ods_table_s3_prefix "cubic/ods_qlik/EDW.LANGUAGE/"
+
+  def up do
+    ods_table_rec = Repo.insert!(%CubicTable{
+      name: @ods_table_name,
+      s3_prefix: @ods_table_s3_prefix,
+      is_raw: true
+    })
+    Repo.insert!(%CubicOdsTableSnapshot{
+      table_id: ods_table_rec.id,
+      snapshot_s3_key: "#{@ods_table_s3_prefix}LOAD00000001.csv.gz"
+    })
+  end
+
+  def down do
+    ods_table_rec = CubicTable.get_by!(name: @ods_table_name)
+    Repo.delete!(ods_table_rec)
+    Repo.delete!(CubicOdsTableSnapshot.get_by!(table_id: ods_table_rec.id))
+  end
+end


### PR DESCRIPTION
Asana ticket: [[Action Item] Add EDW.LANGUAGE to be ingested](https://app.asana.com/0/1203891745642455/1204461710399181/f)

associated Devops PR: https://github.com/mbta/devops/pull/930

This adds in the ecto migration for ingesting the new language table. The migration appears successful on my testing:
```
11:49:37.071 [info] == Running 20230508154111 ExCubicIngestion.Repo.Migrations.AddLanguageTable.up/0 forward

11:49:37.096 [debug] QUERY OK db=4.8ms
INSERT INTO "cubic_tables" ("is_raw","name","s3_prefix","inserted_at","updated_at") VALUES ($1,$2,$3,$4,$5) RETURNING "id" [true, "cubic_ods_qlik__edw_language", "cubic/ods_qlik/EDW.LANGUAGE/", ~U[2023-05-08 15:49:37Z], ~U[2023-05-08 15:49:37Z]]

11:49:37.099 [debug] QUERY OK db=1.4ms
INSERT INTO "cubic_ods_table_snapshots" ("snapshot_s3_key","table_id","inserted_at","updated_at") VALUES ($1,$2,$3,$4) RETURNING "id" ["cubic/ods_qlik/EDW.LANGUAGE/LOAD00000001.csv.gz", 153, ~U[2023-05-08 15:49:37Z], ~U[2023-05-08 15:49:37Z]]

11:49:37.100 [info] == Migrated 20230508154111 in 0.0s
```