### PR TITLE
[env+ga] fix: fix versions for building local and on github

### DIFF
--- a/.github/workflows/glue-python-deploy.yaml
+++ b/.github/workflows/glue-python-deploy.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Prepare for installing dependencies and package
         working-directory: ${{github.workspace}}/py_cubic_ingestion
         run: |
-          poetry export --output requirements.txt
+          poetry export --without-hashes --output requirements.txt
           poetry build
       - name: Install dependencies and py_cubic_ingestion package into 'libs'
         working-directory: ${{github.workspace}}/py_cubic_ingestion

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,6 @@ adr-tools 3.0.0
 elixir 1.13.2-otp-24
 erlang 24.2.1
 java openjdk-11
-poetry 1.4.2
-python 3.7.12
+poetry 1.3.2
+python 3.7.17
 terraform 1.1.8

--- a/docker/Dockerfile.glue_2_0__local
+++ b/docker/Dockerfile.glue_2_0__local
@@ -31,7 +31,8 @@ ENV SPARK_HOME=/spark-2.4.3-bin-spark-2.4.3-bin-hadoop2.8
 RUN /glue/bin/gluesparksubmit --version
 
 # python packaging
-RUN pip install poetry
+### Note: This version here needs to match .tool-versions
+RUN pip install poetry==1.3.2
 # install py_cubic_ingestion's required python dependencies
 COPY ./py_cubic_ingestion /data_platform/py_cubic_ingestion
 WORKDIR /data_platform/py_cubic_ingestion

--- a/docker/Dockerfile.glue_3_0__local
+++ b/docker/Dockerfile.glue_3_0__local
@@ -32,7 +32,8 @@ ENV SPARK_HOME=/spark-3.1.1-amzn-0-bin-3.2.1-amzn-3
 RUN /glue/bin/gluesparksubmit --version
 
 # python packaging
-RUN pip install poetry
+### Note: This version here needs to match .tool-versions
+RUN pip install poetry==1.3.2
 # install py_cubic_ingestion's required python dependencies
 COPY ./py_cubic_ingestion /data_platform/py_cubic_ingestion
 WORKDIR /data_platform/py_cubic_ingestion

--- a/py_cubic_ingestion/pyproject.toml
+++ b/py_cubic_ingestion/pyproject.toml
@@ -9,7 +9,8 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "3.7.12"
+### Note: This version here needs to match .tool-versions
+python = "3.7.17"
 python-dateutil = "^2.8.2"
 boto3-stubs = {extras = ["glue"], version = "^1.24.23"}
 


### PR DESCRIPTION
Address two issues:
* Glue build was not working, hence we couldn't deploy.
* Local build was failing due to python3.7 version update and a poetry issue with the latest version.
