### PR TITLE
[elixir] feat: scheduled loading of partitions in athena

### DIFF
--- a/ex_cubic_ingestion/config/config.exs
+++ b/ex_cubic_ingestion/config/config.exs
@@ -16,7 +16,17 @@ config :ex_cubic_ingestion, Oban,
     {
       Oban.Plugins.Cron,
       crontab: [
-        {"0 15 * * *", ExCubicIngestion.Workers.ScheduleDmap, max_attempts: 1}
+        {"0 15 * * *", ExCubicIngestion.Workers.ScheduleDmap, max_attempts: 1},
+        {"0 * * * *", ExCubicIngestion.Workers.LoadPartitions,
+         args: %{
+           table_names: [
+             "raw_cubic_ods_qlik__edw_fnp_general_jrnl_account_entry",
+             "raw_cubic_ods_qlik__edw_fnp_general_jrnl_account_entry__ct",
+             "raw_cubic_ods_qlik__edw_cch_afc_transaction",
+             "raw_cubic_ods_qlik__edw_cch_afc_transaction__ct"
+           ]
+         },
+         max_attempts: 1}
       ]
     }
   ],

--- a/ex_cubic_ingestion/lib/ex_aws/ex_aws_athena.ex
+++ b/ex_cubic_ingestion/lib/ex_aws/ex_aws_athena.ex
@@ -1,0 +1,49 @@
+defmodule ExAws.Athena do
+  @moduledoc """
+  ExAws.Athena module for making Athena requests.
+  See https://github.com/aws/aws-sdk-go/blob/main/models/apis/athena/2017-05-18/api-2.json
+  for constructing further requests.
+  """
+
+  require Ecto
+
+  @doc """
+  Build operation for 'start_query_execution' API
+  """
+  @spec start_query_execution(String.t(), map()) :: ExAws.Operation.t()
+  def start_query_execution(query_string, result_configuration) do
+    %ExAws.Operation.JSON{
+      http_method: :post,
+      path: "/",
+      headers: [
+        {"x-amz-target", "AmazonAthena.StartQueryExecution"},
+        {"content-type", "application/x-amz-json-1.1"}
+      ],
+      data: %{
+        ClientRequestToken: Ecto.UUID.generate(),
+        QueryString: query_string,
+        ResultConfiguration: result_configuration
+      },
+      service: :athena
+    }
+  end
+
+  @doc """
+  Build operation for 'batch_get_query_execution' API
+  """
+  @spec batch_get_query_execution([String.t()]) :: ExAws.Operation.t()
+  def batch_get_query_execution(query_execution_ids) do
+    %ExAws.Operation.JSON{
+      http_method: :post,
+      path: "/",
+      headers: [
+        {"x-amz-target", "AmazonAthena.BatchGetQueryExecution"},
+        {"content-type", "application/x-amz-json-1.1"}
+      ],
+      data: %{
+        QueryExecutionIds: query_execution_ids
+      },
+      service: :athena
+    }
+  end
+end

--- a/ex_cubic_ingestion/lib/ex_aws/ex_aws_glue.ex
+++ b/ex_cubic_ingestion/lib/ex_aws/ex_aws_glue.ex
@@ -1,6 +1,8 @@
 defmodule ExAws.Glue do
   @moduledoc """
-  ExAws.Glue module.
+  ExAws.Glue module for making Glue requests.
+  See https://github.com/aws/aws-sdk-go/blob/main/models/apis/glue/2017-03-31/api-2.json
+  for constructing further requests.
   """
 
   @spec start_job_run(String.t(), map()) :: ExAws.Operation.t()

--- a/ex_cubic_ingestion/lib/ex_aws/helpers.ex
+++ b/ex_cubic_ingestion/lib/ex_aws/helpers.ex
@@ -3,8 +3,10 @@ defmodule ExAws.Helpers do
   Central place for useful functions that do ExAws work.
   """
 
+  require Logger
+
   @doc """
-  Performs checks, before copying the source object to a destination object
+  S3: Performs checks, before copying the source object to a destination object
   and deleting the source object (moving).
   """
   @spec move(module(), String.t(), String.t(), String.t(), String.t()) ::
@@ -44,5 +46,64 @@ defmodule ExAws.Helpers do
           {:error, copy_req_response}
         end
     end
+  end
+
+  @doc """
+  Athena: Do a batch call to get the status of all the query executions. Based on all the
+  statuses, return :ok if all succeeded, and {:error, ...} otherwise.
+  """
+  @spec monitor_athena_query_executions(module(), [{:ok, map()}]) :: :ok | {:error, String.t()}
+  def monitor_athena_query_executions(lib_ex_aws, success_requests) do
+    {request_status, %{"QueryExecutions" => query_executions}} =
+      success_requests
+      |> Enum.map(fn {:ok, %{"QueryExecutionId" => query_execution_id}} ->
+        query_execution_id
+      end)
+      |> get_athena_query_executions_status(lib_ex_aws)
+
+    # return ok only if all the queries succeeded
+    with :ok <- request_status,
+         true <- queries_succeeded?(query_executions) do
+      Logger.info("Athena Query Executions Status: #{Jason.encode!(query_executions)}")
+
+      :ok
+    else
+      _errored ->
+        {:error, "Athena Batch Get Query Execution: #{Jason.encode!(query_executions)}"}
+    end
+  end
+
+  @spec get_athena_query_executions_status([String.t()], module()) ::
+          {:ok, map()} | {:error, String.t()}
+  defp get_athena_query_executions_status(query_execution_ids, lib_ex_aws) do
+    # pause a litte before getting status
+    Process.sleep(2_000)
+
+    batch_get_query_execution_request =
+      query_execution_ids
+      |> ExAws.Athena.batch_get_query_execution()
+      |> lib_ex_aws.request()
+
+    with {:ok, %{"QueryExecutions" => query_executions}} <- batch_get_query_execution_request,
+         true <- queries_running?(query_executions) do
+      Logger.info("Athena Query Executions Status: #{Jason.encode!(query_executions)}")
+
+      get_athena_query_executions_status(query_execution_ids, lib_ex_aws)
+    else
+      _succeeded_or_errored ->
+        batch_get_query_execution_request
+    end
+  end
+
+  defp queries_running?(query_executions) do
+    Enum.any?(query_executions, fn %{"Status" => %{"State" => state}} ->
+      state == "QUEUED" || state == "RUNNING"
+    end)
+  end
+
+  defp queries_succeeded?(query_executions) do
+    Enum.all?(query_executions, fn %{"Status" => %{"State" => state}} ->
+      state == "SUCCEEDED"
+    end)
   end
 end

--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/load_partitions.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/load_partitions.ex
@@ -1,0 +1,65 @@
+defmodule ExCubicIngestion.Workers.LoadPartitions do
+  @moduledoc """
+  This worker will run every hour to refresh partitions for Athena
+  for a few select tables.
+  """
+
+  use Oban.Worker,
+    queue: :load_partitions,
+    max_attempts: 1
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%{args: args} = _job) do
+    %{"table_names" => table_names} = args
+
+    # allow for ex_aws module to be passed in as a string, since Oban will need to
+    # serialize args to JSON. defaulted to library module.
+    lib_ex_aws =
+      case args do
+        %{"lib_ex_aws" => mod_str} -> Module.safe_concat([mod_str])
+        _args_lib_ex_aws -> ExAws
+      end
+
+    case start_load_partitions(lib_ex_aws, table_names) do
+      # if all succesful, monitor their status
+      {[_first | _rest] = success_requests, []} ->
+        ExAws.Helpers.monitor_athena_query_executions(lib_ex_aws, success_requests)
+
+      # if any failures, fail the job as well
+      {_success_requests, error_requests} ->
+        error_requests_bodies =
+          error_requests
+          |> Enum.map(fn {:error, {exception, message}} ->
+            %{exception: exception, message: message}
+          end)
+          |> Jason.encode!()
+
+        {:error, "Athena Start Query Executions: #{error_requests_bodies}"}
+    end
+  end
+
+  @spec start_load_partitions(module(), [String.t()]) :: {[{:ok, map()}], [{:error, map()}]}
+  def start_load_partitions(lib_ex_aws, table_names) do
+    bucket_operations = Application.fetch_env!(:ex_cubic_ingestion, :s3_bucket_operations)
+    prefix_operations = Application.fetch_env!(:ex_cubic_ingestion, :s3_bucket_prefix_operations)
+
+    table_names
+    # make requests to start loading partitions
+    |> Enum.map(fn table ->
+      # sleep a little to avoid throttling
+      Process.sleep(100)
+
+      "MSCK REPAIR TABLE #{table};"
+      |> ExAws.Athena.start_query_execution(%{
+        OutputLocation: "s3://#{bucket_operations}/#{prefix_operations}athena/"
+      })
+      |> lib_ex_aws.request()
+    end)
+    # split into successful requests and failures
+    |> Enum.split_with(fn {status, _response_body} ->
+      status == :ok
+    end)
+  end
+end

--- a/ex_cubic_ingestion/test/ex_aws/helpers_test.exs
+++ b/ex_cubic_ingestion/test/ex_aws/helpers_test.exs
@@ -67,4 +67,25 @@ defmodule ExAws.HelpersTest do
                )
     end
   end
+
+  describe "monitor_athena_query_executions/2" do
+    test "returns immediately if all queries have succeeded" do
+      query_executions = [
+        {:ok, %{"QueryExecutionId" => "success_query_id_1"}},
+        {:ok, %{"QueryExecutionId" => "success_query_id_2"}}
+      ]
+
+      assert :ok = ExAws.Helpers.monitor_athena_query_executions(MockExAws, query_executions)
+    end
+
+    test "returns immediately if any of the queries have failed or were cancelled" do
+      query_executions = [
+        {:ok, %{"QueryExecutionId" => "cancel_query_id"}},
+        {:ok, %{"QueryExecutionId" => "fail_query_id"}}
+      ]
+
+      assert {:error, _message} =
+               ExAws.Helpers.monitor_athena_query_executions(MockExAws, query_executions)
+    end
+  end
 end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/load_partitions_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/load_partitions_test.exs
@@ -1,0 +1,42 @@
+defmodule ExCubicIngestion.Workers.LoadPartitionsTest do
+  use ExCubicIngestion.DataCase, async: true
+  use Oban.Testing, repo: ExCubicIngestion.Repo
+
+  alias ExCubicIngestion.Workers.LoadPartitions
+
+  require MockExAws
+
+  describe "perform/1" do
+    test "running job" do
+      # success
+      assert :ok =
+               perform_job(LoadPartitions, %{
+                 table_names: ["success_table"],
+                 lib_ex_aws: "MockExAws"
+               })
+
+      # fail
+      assert {:error, _message} =
+               perform_job(LoadPartitions, %{
+                 table_names: ["fail_table"],
+                 lib_ex_aws: "MockExAws"
+               })
+    end
+  end
+
+  describe "start_load_partitions/2" do
+    test "starting query executions with successes and failures" do
+      # both
+      assert {[{:ok, _response}], [{:error, {"Exception", _message}}]} =
+               LoadPartitions.start_load_partitions(MockExAws, ["success_table", "fail_table"])
+
+      # just successes
+      assert {[{:ok, _response}], []} =
+               LoadPartitions.start_load_partitions(MockExAws, ["success_table"])
+
+      # just failures
+      assert {[], [{:error, {"Exception", _message}}]} =
+               LoadPartitions.start_load_partitions(MockExAws, ["fail_table"])
+    end
+  end
+end

--- a/ex_cubic_ingestion/test/support/ex_aws.ex
+++ b/ex_cubic_ingestion/test/support/ex_aws.ex
@@ -350,6 +350,62 @@ defmodule MockExAws do
     end
   end
 
+  def request(
+        %{service: :athena, data: %{QueryExecutionIds: ["success_query_id"]}},
+        _config_overrides
+      ) do
+    {:ok, %{"QueryExecutions" => [%{"Status" => %{"State" => "SUCCEEDED"}}]}}
+  end
+
+  def request(
+        %{
+          service: :athena,
+          data: %{QueryExecutionIds: ["success_query_id_1", "success_query_id_2"]}
+        },
+        _config_overrides
+      ) do
+    {:ok,
+     %{
+       "QueryExecutions" => [
+         %{"Status" => %{"State" => "SUCCEEDED"}},
+         %{"Status" => %{"State" => "SUCCEEDED"}}
+       ]
+     }}
+  end
+
+  def request(
+        %{service: :athena, data: %{QueryExecutionIds: ["cancel_query_id", "fail_query_id"]}},
+        _config_overrides
+      ) do
+    {:ok,
+     %{
+       "QueryExecutions" => [
+         %{"Status" => %{"State" => "CANCELLED"}},
+         %{"Status" => %{"State" => "FAILED"}}
+       ]
+     }}
+  end
+
+  def request(
+        %{
+          service: :athena,
+          data: %{QueryString: "MSCK REPAIR TABLE success_table;"}
+        },
+        _config_overrides
+      ) do
+    {:ok, %{"QueryExecutionId" => "success_query_id"}}
+  end
+
+  def request(
+        %{
+          service: :athena,
+          data: %{QueryString: "MSCK REPAIR TABLE fail_table;"}
+        },
+        _config_overrides
+      ) do
+    {:error, {"Exception", "fail_table issue message"}}
+  end
+
   @spec request!(ExAws.Operation.t(), keyword) :: term
   def request!(op, config_overrides \\ []) do
     case request(op, config_overrides) do


### PR DESCRIPTION
Note: This work is related to the deployment of the data pipeline to Production.
The system will need to refresh partitions for some tables in Athena, so we are scheduling a job to run every hour to do so. The reason for the refresh is so our queries will return data under those partitions.
Without this job, we'd have to do something more manual. Not to mention that we'd need permissions to do it against live data.

**This work is dependent on a DevOps PR (forthcoming) to allow permissions for ECS to access Athena.**