### PR TITLE
[elixir] feat: only run athena queries within a workgroup

### DIFF
--- a/ex_cubic_ingestion/config/runtime.exs
+++ b/ex_cubic_ingestion/config/runtime.exs
@@ -31,4 +31,5 @@ config :ex_cubic_ingestion,
   glue_job_cubic_ingestion_ingest_incoming:
     System.get_env("GLUE_JOB_CUBIC_INGESTION_INGEST_INCOMING", ""),
   dmap_base_url: System.get_env("CUBIC_DMAP_BASE_URL", ""),
-  dmap_api_key: System.get_env("CUBIC_DMAP_API_KEY", "")
+  dmap_api_key: System.get_env("CUBIC_DMAP_API_KEY", ""),
+  athena_workgroup: System.get_env("ATHENA_WORKGROUP", "")

--- a/ex_cubic_ingestion/lib/ex_aws/ex_aws_athena.ex
+++ b/ex_cubic_ingestion/lib/ex_aws/ex_aws_athena.ex
@@ -22,7 +22,8 @@ defmodule ExAws.Athena do
       data: %{
         ClientRequestToken: Ecto.UUID.generate(),
         QueryString: query_string,
-        ResultConfiguration: result_configuration
+        ResultConfiguration: result_configuration,
+        WorkGroup: Application.fetch_env!(:ex_cubic_ingestion, :athena_workgroup)
       },
       service: :athena
     }


### PR DESCRIPTION
By using workgroups, we constrain Athena's access to only Cubic data.

Corresponding DevOps PR: https://github.com/mbta/devops/pull/1254