### PR TITLE
[elixir] feat: hide any url details if dmap errors on fetch

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/fetch_dmap.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/fetch_dmap.ex
@@ -90,12 +90,18 @@ defmodule ExCubicIngestion.Workers.FetchDmap do
 
   @doc """
   Using the feed record to construct a URL and get the contents containing the dataset
-  information. Also, checks that datasets are valid an filters out invalid ones.
+  information. Also, checks that datasets are valid and filters out invalid ones.
   """
   @spec get_feed_datasets(CubicDmapFeed.t(), String.t() | nil, module()) :: [map()]
   def get_feed_datasets(feed_rec, last_updated, lib_httpoison) do
-    %HTTPoison.Response{status_code: 200, body: body} =
-      lib_httpoison.get!(construct_feed_url(feed_rec, last_updated))
+    body =
+      case lib_httpoison.get(construct_feed_url(feed_rec, last_updated)) do
+        {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+          body
+
+        _exception_or_error_code ->
+          raise "Unable to fetch feed results: #{feed_rec.relative_url}"
+      end
 
     body
     |> Jason.decode!()

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/fetch_dmap_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/fetch_dmap_test.exs
@@ -129,6 +129,26 @@ defmodule ExCubicIngestion.Workers.FetchDmapTest do
                  & &1["dataset_id"]
                )
     end
+
+    test "api key not logged when error in fetching mock feed results" do
+      relative_url = "/datasetpublicusersapi/error"
+
+      dmap_feed =
+        Repo.insert!(%CubicDmapFeed{
+          relative_url: relative_url,
+          last_updated_at: ~U[2022-05-22 20:49:50.123456Z]
+        })
+
+      last_updated = ~U[2022-05-01 10:49:50.123456Z]
+
+      assert_raise RuntimeError, "Unable to fetch feed results: #{relative_url}", fn ->
+        FetchDmap.get_feed_datasets(
+          dmap_feed,
+          DateTime.to_string(last_updated),
+          MockHTTPoison
+        )
+      end
+    end
   end
 
   describe "fetch_and_upload_to_s3/1" do

--- a/ex_cubic_ingestion/test/support/httpoison.ex
+++ b/ex_cubic_ingestion/test/support/httpoison.ex
@@ -3,44 +3,57 @@ defmodule MockHTTPoison do
   Allow for controlling what is returned for a HTTPoison request.
   """
 
-  @spec get!(String.t()) :: HTTPoison.Response.t()
-  def get!(url) do
+  @spec get(String.t()) :: {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+  def get(url) do
     dmap_base_url = Application.fetch_env!(:ex_cubic_ingestion, :dmap_base_url)
 
     cond do
       String.starts_with?(url, "#{dmap_base_url}/datasetpublicusersapi/sample") ->
-        %HTTPoison.Response{
-          status_code: 200,
-          body: """
-          {
-            "success": true,
-            "results": [
-              {
-                "id": "sample",
-                "dataset_id": "sample_20220517",
-                "url": "https://mbtaqadmapdatalake.blob.core.windows.net/sample/sample_2022-05-17.csv.gz",
-                "start_date": "2022-05-17",
-                "end_date": "2022-05-17",
-                "last_updated": "2022-05-18T13:39:43.546303"
-              },
-              {
-                "id": "sample",
-                "dataset_id": "sample_20220518",
-                "url": "https://mbtaqadmapdatalake.blob.core.windows.net/sample/sample_2022-05-18.csv.gz",
-                "start_date": "2022-05-18",
-                "end_date": "2022-05-18",
-                "last_updated": "2022-05-19T12:12:44.737440"
-              }
-            ]
-          }
-          """
-        }
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: """
+           {
+             "success": true,
+             "results": [
+               {
+                 "id": "sample",
+                 "dataset_id": "sample_20220517",
+                 "url": "https://mbtaqadmapdatalake.blob.core.windows.net/sample/sample_2022-05-17.csv.gz",
+                 "start_date": "2022-05-17",
+                 "end_date": "2022-05-17",
+                 "last_updated": "2022-05-18T13:39:43.546303"
+               },
+               {
+                 "id": "sample",
+                 "dataset_id": "sample_20220518",
+                 "url": "https://mbtaqadmapdatalake.blob.core.windows.net/sample/sample_2022-05-18.csv.gz",
+                 "start_date": "2022-05-18",
+                 "end_date": "2022-05-18",
+                 "last_updated": "2022-05-19T12:12:44.737440"
+               }
+             ]
+           }
+           """
+         }}
 
-      String.starts_with?(url, "https://mbtaqadmapdatalake.blob.core.windows.net/sample") ->
-        %HTTPoison.Response{status_code: 200, body: "sample_body"}
+      String.starts_with?(url, "#{dmap_base_url}/datasetpublicusersapi/error") ->
+        # bad request
+        {:ok, %HTTPoison.Response{status_code: 400, body: "{}"}}
 
       true ->
-        %HTTPoison.Response{status_code: 404, body: ""}
+        {:error, %HTTPoison.Error{}}
+    end
+  end
+
+  @spec get!(String.t()) :: HTTPoison.Response.t()
+  def get!(url) do
+    dmap_base_url = Application.fetch_env!(:ex_cubic_ingestion, :dmap_base_url)
+
+    if String.starts_with?(url, "https://mbtaqadmapdatalake.blob.core.windows.net/sample") do
+      %HTTPoison.Response{status_code: 200, body: "sample_body"}
+    else
+      %HTTPoison.Response{status_code: 404, body: ""}
     end
   end
 end


### PR DESCRIPTION
Prevent the logging of any URL information on an error or exception when calling the DMAP feeds, especially API keys being used.