### PR TITLE
[elixir] feat: get response body on dmap fetch error

### DIFF
--- a/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/fetch_dmap.ex
+++ b/ex_cubic_ingestion/lib/ex_cubic_ingestion/workers/fetch_dmap.ex
@@ -99,6 +99,9 @@ defmodule ExCubicIngestion.Workers.FetchDmap do
         {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
           body
 
+        {:ok, %HTTPoison.Response{body: body}} ->
+          raise "Unable to fetch feed results: #{feed_rec.relative_url} (Response: #{inspect(body)})"
+
         _exception_or_error_code ->
           raise "Unable to fetch feed results: #{feed_rec.relative_url}"
       end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/fetch_dmap_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/fetch_dmap_test.exs
@@ -130,8 +130,30 @@ defmodule ExCubicIngestion.Workers.FetchDmapTest do
                )
     end
 
-    test "api key not logged when error in fetching mock feed results" do
+    test "getting error response and throwing specific exception with response body" do
       relative_url = "/datasetpublicusersapi/error"
+
+      dmap_feed =
+        Repo.insert!(%CubicDmapFeed{
+          relative_url: relative_url,
+          last_updated_at: ~U[2022-05-22 20:49:50.123456Z]
+        })
+
+      last_updated = ~U[2022-05-01 10:49:50.123456Z]
+
+      assert_raise RuntimeError,
+                   "Unable to fetch feed results: #{relative_url} (Response: \"{}\")",
+                   fn ->
+                     FetchDmap.get_feed_datasets(
+                       dmap_feed,
+                       DateTime.to_string(last_updated),
+                       MockHTTPoison
+                     )
+                   end
+    end
+
+    test "getting error response and throwing specific exception" do
+      relative_url = "/datasetpublicusersapi/exception"
 
       dmap_feed =
         Repo.insert!(%CubicDmapFeed{


### PR DESCRIPTION
DMAP feed fetch is failing on production, and I'm not sure why. This PR exposes the response body to see if Cubic is returning an error.