### PR TITLE
[elixir] feat: add is_active to cubic tables and filter not active from ingestion

### DIFF
--- a/ex_cubic_ingestion/priv/repo/migrations/20220825021933_update_snapshot_key_for_sample.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20220825021933_update_snapshot_key_for_sample.exs
@@ -1,20 +1,22 @@
 defmodule ExCubicIngestion.Repo.Migrations.UpdateSnapshotKeyForSample do
   use Ecto.Migration
 
+  import Ecto.Query
+
   alias ExCubicIngestion.Repo
   alias ExCubicIngestion.Schema.CubicTable
   alias ExCubicIngestion.Schema.CubicOdsTableSnapshot
 
   def up do
-    table_rec = Repo.get_by!(CubicTable, name: "cubic_ods_qlik__edw_sample")
-    ods_table_snapshot_rec = Repo.get_by!(CubicOdsTableSnapshot, table_id: table_rec.id)
+    table_id = Repo.get_by!(from(table in CubicTable, select: table.id), name: "cubic_ods_qlik__edw_sample")
+    ods_table_snapshot_rec = Repo.get_by!(CubicOdsTableSnapshot, table_id: table_id)
 
     Repo.update!(Ecto.Changeset.change(ods_table_snapshot_rec, snapshot_s3_key: "cubic/ods_qlik/EDW.SAMPLE/LOAD1.csv.gz"))
   end
 
   def down do
-    table_rec = Repo.get_by!(CubicTable, name: "cubic_ods_qlik__edw_sample")
-    ods_table_snapshot_rec = Repo.get_by!(CubicOdsTableSnapshot, table_id: table_rec.id)
+    table_id = Repo.get_by!(from(table in CubicTable, select: table.id), name: "cubic_ods_qlik__edw_sample")
+    ods_table_snapshot_rec = Repo.get_by!(CubicOdsTableSnapshot, table_id: table_id)
 
     Repo.update!(Ecto.Changeset.change(ods_table_snapshot_rec, snapshot_s3_key: "cubic/ods_qlik/EDW.SAMPLE/LOAD1.csv"))
   end

--- a/ex_cubic_ingestion/priv/repo/migrations/20231229210357_add_is_active_for_cubic_tables.exs
+++ b/ex_cubic_ingestion/priv/repo/migrations/20231229210357_add_is_active_for_cubic_tables.exs
@@ -1,0 +1,24 @@
+defmodule ExCubicIngestion.Repo.Migrations.AddIsActiveForCubicTables do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias ExCubicIngestion.Repo
+  alias ExCubicIngestion.Schema.CubicTable
+
+  def up do
+    alter table(:cubic_tables) do
+      add :is_active, :boolean
+    end
+
+    flush()
+
+    Repo.update_all(from(table in CubicTable, where: is_nil(table.deleted_at)), set: [is_active: true])
+  end
+
+  def down do
+    alter table(:cubic_tables) do
+      remove :is_active
+    end
+  end
+end

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/process_incoming_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/process_incoming_test.exs
@@ -32,7 +32,8 @@ defmodule ExCubicIngestion.ProcessIncomingTest do
       dmap_table =
         Repo.insert!(%CubicTable{
           name: "cubic_dmap__sample",
-          s3_prefix: "cubic/dmap/sample/"
+          s3_prefix: "cubic/dmap/sample/",
+          is_active: true
         })
 
       dmap_table_id = dmap_table.id
@@ -40,7 +41,8 @@ defmodule ExCubicIngestion.ProcessIncomingTest do
       ods_table =
         Repo.insert!(%CubicTable{
           name: "cubic_ods_qlik__sample",
-          s3_prefix: "cubic/ods_qlik/SAMPLE/"
+          s3_prefix: "cubic/ods_qlik/SAMPLE/",
+          is_active: true
         })
 
       Repo.insert!(%CubicOdsTableSnapshot{

--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_table_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/schema/cubic_table_test.exs
@@ -40,13 +40,22 @@ defmodule ExCubicIngestion.Schema.CubicTableTest do
       dmap_table =
         Repo.insert!(%CubicTable{
           name: "cubic_dmap__sample",
-          s3_prefix: "cubic/dmap/sample/"
+          s3_prefix: "cubic/dmap/sample/",
+          is_active: true
         })
+
+      # adding an inactive table
+      Repo.insert!(%CubicTable{
+        name: "cubic_dmap__sample_inactive",
+        s3_prefix: "cubic/dmap/sample_inactive/",
+        is_active: false
+      })
 
       ods_table =
         Repo.insert!(%CubicTable{
           name: "cubic_ods_qlik__sample",
-          s3_prefix: "cubic/ods_qlik/SAMPLE/"
+          s3_prefix: "cubic/ods_qlik/SAMPLE/",
+          is_active: true
         })
 
       Repo.insert!(%CubicOdsTableSnapshot{
@@ -57,6 +66,7 @@ defmodule ExCubicIngestion.Schema.CubicTableTest do
       # note: purposely leaving out incoming bucket prefix config
       prefixes = [
         "cubic/dmap/sample/",
+        "cubic/dmap/sample_inactive/",
         "cubic/dmap/sample_table_wrong/",
         "cubic/ods_qlik/SAMPLE/",
         "cubic/ods_qlik/SAMPLE__ct/",


### PR DESCRIPTION
I'm planning on adding an "Admin" area to manage the "active" status of tables. I will continue to manage migrations in `ex_cubic_ingestion`, so hence this change.
This PR also introduced the filtering by active on incoming loads.