### PR TITLE
[elixir] fix: dmap ingestion implementation is not complete, so turn off

### DIFF
--- a/ex_cubic_ingestion/config/config.exs
+++ b/ex_cubic_ingestion/config/config.exs
@@ -13,12 +13,12 @@ config :ex_cubic_ingestion,
 config :ex_cubic_ingestion, Oban,
   repo: ExCubicIngestion.Repo,
   plugins: [
-    {
-      Oban.Plugins.Cron,
-      crontab: [
-        {"0 15 * * *", ExCubicIngestion.Workers.ScheduleDmap, max_attempts: 1}
-      ]
-    }
+    # {
+    #   Oban.Plugins.Cron,
+    #   crontab: [
+    #     {"0 15 * * *", ExCubicIngestion.Workers.ScheduleDmap, max_attempts: 1}
+    #   ]
+    # }
   ],
   queues: [
     archive: 1,


### PR DESCRIPTION
DMAP is being ingested but currently the implementation does not have a lot of cases covered that can cause issues for other data being ingested.

The two things currently identified are:
1. There is no schema validation. If the DMAP schema changes the ingestion process is not checking and will fail the glue job.
2. No support for "empty" data in the DMAP feeds. A recent change to the implementation of DMAP allows for empty datasets to show up. I am not currently sure that the ingestion done here accounts for that and/or that Glue is able to ignore it.

For these reasons, and the fact that we have an alternative way to get at DMAP data, I'm opting to turn this off for now.
