### PR TITLE
[elixir] feat: remove invalid schema check and glue job

### DIFF
--- a/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/ingest_test.exs
+++ b/ex_cubic_ingestion/test/ex_cubic_ingestion/workers/ingest_test.exs
@@ -102,14 +102,14 @@ defmodule ExCubicIngestion.Workers.IngestTest do
 
   describe "handle_start_glue_job_error/1" do
     test "receiving a max concurrency exceeded error" do
-      assert {:snooze, 60} =
+      assert {:snooze, 1} =
                Ingest.handle_start_glue_job_error(
                  {:error, {"ConcurrentRunsExceededException", "An error occurred."}}
                )
     end
 
     test "receiving a throttling error" do
-      assert {:snooze, 60} =
+      assert {:snooze, 1} =
                Ingest.handle_start_glue_job_error(
                  {:error, {"ThrottlingException", "An error occurred."}}
                )

--- a/ex_cubic_ingestion/test/support/ex_aws.ex
+++ b/ex_cubic_ingestion/test/support/ex_aws.ex
@@ -117,34 +117,6 @@ defmodule MockExAws do
            """
          }}
 
-      path == "#{incoming_prefix}cubic/ods_qlik/SAMPLE/invalid_LOAD2.dfm" ->
-        {:ok,
-         %{
-           body: """
-            {
-                "dataInfo": {
-                    "columns": [
-                        {
-                            "name": "SAMPLE_ID"
-                        },
-                        {
-                            "name": "SAMPLE_NAME"
-                        },
-                        {
-                            "name": "EDW_INSERTED_DTM"
-                        },
-                        {
-                            "name": "EDW_UPDATED_DTM"
-                        },
-                        {
-                            "name": "INVALID_COLUMN"
-                        }
-                    ]
-                }
-            }
-           """
-         }}
-
       path == "#{incoming_prefix}cubic/ods_qlik/SAMPLE/notfound_LOAD3.dfm" ->
         {:error,
          {:http_error, 404,


### PR DESCRIPTION
* We are turning off glue jobs at this time, as the output it generates are not in use. Most users of the data are looking in the DMAP Import database.
* We also turn off schema validation, as it is done in other pipelines prior to ingestion into the DMAP Import database, and soon ODIN.